### PR TITLE
Fix compiler errors for scala 2.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -469,3 +469,10 @@ website/static/api
 
 # native-libs
 dynamodb/native-libs
+
+# nix
+shell.nix
+
+# direnv
+.envrc
+.direnv

--- a/build.sbt
+++ b/build.sbt
@@ -284,9 +284,13 @@ lazy val zioDynamodb = module("zio-dynamodb", "dynamodb")
            |      EitherUtil
            |        .forEach(fields) {
            |          case Schema.Field(key, schema, _) =>
-           |            val dec        = decoder(schema)
-           |            val maybeValue = map.get(AttributeValue.String(key))
-           |            maybeValue.map(dec).toRight(s"field '$$key' not found in $$av").flatten
+           |            val dec          = decoder(schema)
+           |            val maybeValue   = map.get(AttributeValue.String(key))
+           |            val maybeDecoder = maybeValue.map(dec).toRight(s"field '$$key' not found in $$av")
+           |            for {
+           |              decoder <- maybeDecoder
+           |              decoded <- decoder
+           |            } yield decoded
            |        }
            |        .map(_.toList)
            |    case _                       =>

--- a/dynamodb/src/main/scala/zio/dynamodb/AliasMap.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/AliasMap.scala
@@ -1,6 +1,6 @@
 package zio.dynamodb
 
-final case class AliasMap private (map: Map[AttributeValue, String], index: Int = 0) { self =>
+final case class AliasMap private (map: Map[AttributeValue, String], index: Int) { self =>
   private def +(entry: AttributeValue): (AliasMap, String) = {
     val variableAlias = s":v${self.index}"
     (AliasMap(self.map + ((entry, variableAlias)), self.index + 1), variableAlias)

--- a/dynamodb/src/main/scala/zio/dynamodb/Decoder.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Decoder.scala
@@ -281,7 +281,7 @@ private[dynamodb] object Decoder extends GeneratedCaseClassDecoders {
                 case Left(s)     => Left(s)
               }
           }
-          EitherUtil.collectAll(xs).map(Map.from)
+          EitherUtil.collectAll(xs).map(elems => Map.newBuilder[String, V].++=(elems).result())
         case av                      => Left(s"Error: expected AttributeValue.Map but found $av")
       }
     }
@@ -296,7 +296,7 @@ private[dynamodb] object Decoder extends GeneratedCaseClassDecoders {
             case av                              =>
               Left(s"Error: expected AttributeValue.List but found $av")
           }
-          x.map(Map.from)
+          x.map(elems => Map.newBuilder[A, B].++=(elems).result())
         case av                            => Left(s"Error: expected AttributeValue.List but found $av")
       }
     }

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -534,7 +534,7 @@ private[dynamodb] final case class DynamoDBExecutorImpl private (dynamoDb: Dynam
       )
     )
     keySchema.sortKey.fold(hashKeyElement)(sortKey =>
-      hashKeyElement.appended(KeySchemaElement(attributeName = sortKey, keyType = KeyType.RANGE))
+      hashKeyElement :+ KeySchemaElement(attributeName = sortKey, keyType = KeyType.RANGE)
     )
   }
 

--- a/dynamodb/src/main/scala/zio/dynamodb/FromAttributeValue.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/FromAttributeValue.scala
@@ -80,7 +80,7 @@ object FromAttributeValue {
     case av                        => Left(s"Error getting BigDecimal value. Expected AttributeValue.Number but found $av")
   }
   implicit val bigDecimalSetFromAttributeValue: FromAttributeValue[Set[BigDecimal]] = {
-    case AttributeValue.NumberSet(bdSet) => Right(bdSet.map(_.bigDecimal))
+    case AttributeValue.NumberSet(bdSet) => Right(bdSet)
     case av                              => Left(s"Error getting BigDecimal set value. Expected AttributeValue.Number but found $av")
   }
 


### PR DESCRIPTION
This fixes compiler errors for scala 2.12. I also added a few files to the .gitignore that are for nix. After this we should be able to successfully do a test release. 

Do we want to also have +test or +compile to make sure 2.12 still compiles on normal PRs?
