### PR TITLE
Scan all par

### DIFF
--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -235,7 +235,7 @@ object LiveSpec extends DefaultRunnableSpec {
                             putItem(tableName, item)
                           }.runDrain
                 stream <- scanAllItem(tableName).parallel(8).execute
-                chunk  <- stream.runCollect
+                count  <- stream.fold(0) { case (count, _) => count + 1 }
               } yield assert(chunk.length)(equalTo(10000))
           )
         },

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -238,7 +238,7 @@ object LiveSpec extends DefaultRunnableSpec {
                               }
                               .execute
                           }
-                stream <- scanAllItem(tableName).execute
+                stream <- scanAllItem(tableName).inParallel(8).execute
                 chunk  <- stream.runCollect
               } yield assert(chunk.length)(equalTo(5000))
           )

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -225,6 +225,23 @@ object LiveSpec extends DefaultRunnableSpec {
               chunk  <- stream.runCollect
             } yield assert(chunk)(equalTo(Chunk(aviPerson, avi2Person, avi3Person)))
           }
+        },
+        testM("parallel scan all") {
+          withTemporaryTable(
+            numberTable,
+            tableName =>
+              for {
+                _      <- ZIO.foreachPar_(1 to 200) { i =>
+                            DynamoDBQuery
+                              .forEach(((i - 1) * 25) to (i * 25) - 1) { x =>
+                                putItem(tableName, Item(id -> x))
+                              }
+                              .execute
+                          }
+                stream <- scanAllItem(tableName).execute
+                chunk  <- stream.runCollect
+              } yield assert(chunk.length)(equalTo(5000))
+          )
         }
       ),
       suite("query tables")(
@@ -469,36 +486,34 @@ object LiveSpec extends DefaultRunnableSpec {
             }
           },
           testM("append to list") {
-            withDefaultTable {
-              tableName =>
-                for {
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").set(List(1))).execute
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").appendList(Chunk(2, 3, 4))).execute
-                  // REVIEW(john): Getting None when a projection expression is added here
-                  updated <- getItem(tableName, secondPrimaryKey).execute
-                } yield assert(
-                  updated.map(a =>
-                    a.get("listThing")(
-                      FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
-                    )
+            withDefaultTable { tableName =>
+              for {
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").set(List(1))).execute
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").appendList(Chunk(2, 3, 4))).execute
+                // REVIEW(john): Getting None when a projection expression is added here
+                updated <- getItem(tableName, secondPrimaryKey).execute
+              } yield assert(
+                updated.map(a =>
+                  a.get("listThing")(
+                    FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
                   )
-                )(equalTo(Some(Right(List(1, 2, 3, 4)))))
+                )
+              )(equalTo(Some(Right(List(1, 2, 3, 4)))))
             }
           },
           testM("prepend to list") {
-            withDefaultTable {
-              tableName =>
-                for {
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").set(List(1))).execute
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").prependList(Chunk(-1, 0))).execute
-                  updated <- getItem(tableName, secondPrimaryKey).execute
-                } yield assert(
-                  updated.map(a =>
-                    a.get("listThing")(
-                      FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
-                    )
+            withDefaultTable { tableName =>
+              for {
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").set(List(1))).execute
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").prependList(Chunk(-1, 0))).execute
+                updated <- getItem(tableName, secondPrimaryKey).execute
+              } yield assert(
+                updated.map(a =>
+                  a.get("listThing")(
+                    FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
                   )
-                )(equalTo(Some(Right(List(-1, 0, 1)))))
+                )
+              )(equalTo(Some(Right(List(-1, 0, 1)))))
             }
           },
           testM("set an Item Attribute") {

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -236,7 +236,7 @@ object LiveSpec extends DefaultRunnableSpec {
                           }.runDrain
                 stream <- scanAllItem(tableName).parallel(8).execute
                 count  <- stream.fold(0) { case (count, _) => count + 1 }
-              } yield assert(chunk.length)(equalTo(10000))
+              } yield assert(count)(equalTo(10000))
           )
         },
         testM("parallel scan all typed") {
@@ -251,8 +251,8 @@ object LiveSpec extends DefaultRunnableSpec {
                     putItem(tableName, item)
                   }.runDrain
                 stream <- scanAll[Person](tableName).parallel(8).execute
-                chunk  <- stream.runCollect
-              } yield assert(chunk.length)(equalTo(10000))
+                count  <- stream.fold(0) { case (count, _) => count + 1 }
+              } yield assert(count)(equalTo(10000))
           )
         }
       ),

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -181,11 +181,11 @@ sealed trait DynamoDBQuery[+A] { self =>
       case _                          => self
     }
 
-  def inParallel(n: Int): DynamoDBQuery[A] =
+  def parallel(n: Int): DynamoDBQuery[A] =
     self match {
-      case Zip(left, right, zippable) => Zip(left.inParallel(n), right.inParallel(n), zippable)
-      case Map(query, mapper)         => Map(query.inParallel(n), mapper)
-      case s: ScanAll                 => s.copy(parallel = n).asInstanceOf[DynamoDBQuery[A]]
+      case Zip(left, right, zippable) => Zip(left.parallel(n), right.parallel(n), zippable)
+      case Map(query, mapper)         => Map(query.parallel(n), mapper)
+      case s: ScanAll                 => s.copy(totalSegments = n).asInstanceOf[DynamoDBQuery[A]]
       case _                          => self
     }
 
@@ -662,7 +662,7 @@ object DynamoDBQuery {
     projections: List[ProjectionExpression] = List.empty, // if empty all attributes will be returned
     capacity: ReturnConsumedCapacity = ReturnConsumedCapacity.None,
     select: Option[Select] = None,                        // if ProjectExpression supplied then only valid value is SpecificAttributes
-    parallel: Int = 1                                     // TODO: Greater than 0
+    totalSegments: Int = 1                                // TODO: Greater than 0
   ) extends Constructor[Stream[Throwable, Item]]
 
   object ScanAll {

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -181,6 +181,16 @@ sealed trait DynamoDBQuery[+A] { self =>
       case _                          => self
     }
 
+  // DynamoDBQuery.when(f: A => Boolean) // fail if this is false
+
+  // Could make sense to add a DynamoDBQuery.FailCause that translates to ZIO.failCause
+  // Then if n < 0 just do DynamoDBQuery.dieMessage("n less than 0")
+  // DynamoDBQuery.failCause(cause: Cause[Nothing]) // can only fail for interrupt or fatal
+  // Can implement dieMessage in the same way ZIO does
+  // DyanmoDBQuery.die(throwable: Throwable) // for fatal errors
+
+  // Could do zio-prelude (still moving along quickly but not stable)
+  // would return an either during runtime
   def parallel(n: Int): DynamoDBQuery[A] =
     self match {
       case Zip(left, right, zippable) => Zip(left.parallel(n), right.parallel(n), zippable)

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -181,16 +181,13 @@ sealed trait DynamoDBQuery[+A] { self =>
       case _                          => self
     }
 
-  // DynamoDBQuery.when(f: A => Boolean) // fail if this is false
+  /**
+   * Parallel executes DynamoDB queries in parallel if the query type has parallel features in DynamoDB.
+   * There are no guarantees on order of returned items.
+   *
+   * @param n The number of parallel requests to make to DynamoDB
+   */
 
-  // Could make sense to add a DynamoDBQuery.FailCause that translates to ZIO.failCause
-  // Then if n < 0 just do DynamoDBQuery.dieMessage("n less than 0")
-  // DynamoDBQuery.failCause(cause: Cause[Nothing]) // can only fail for interrupt or fatal
-  // Can implement dieMessage in the same way ZIO does
-  // DyanmoDBQuery.die(throwable: Throwable) // for fatal errors
-
-  // Could do zio-prelude (still moving along quickly but not stable)
-  // would return an either during runtime
   def parallel(n: Int): DynamoDBQuery[A] =
     self match {
       case Zip(left, right, zippable) => Zip(left.parallel(n), right.parallel(n), zippable)

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -330,8 +330,8 @@ object DynamoDBQuery {
   def succeed[A](a: A): DynamoDBQuery[A] = Succeed(() => a)
 
   def forEach[A, B](values: Iterable[A])(body: A => DynamoDBQuery[B]): DynamoDBQuery[List[B]] =
-    values.foldLeft[DynamoDBQuery[List[B]]](succeed(Nil)) {
-      case (query, a) => body(a).zipWith(query)(_ :: _)
+    values.foldRight[DynamoDBQuery[List[B]]](succeed(Nil)) {
+      case (a, query) => body(a).zipWith(query)(_ :: _)
     }
 
   def getItem(
@@ -672,7 +672,7 @@ object DynamoDBQuery {
     projections: List[ProjectionExpression] = List.empty, // if empty all attributes will be returned
     capacity: ReturnConsumedCapacity = ReturnConsumedCapacity.None,
     select: Option[Select] = None,                        // if ProjectExpression supplied then only valid value is SpecificAttributes
-    totalSegments: Int = 1                                // TODO: Greater than 0
+    totalSegments: Int = 1
   ) extends Constructor[Stream[Throwable, Item]]
 
   object ScanAll {

--- a/dynamodb/src/main/scala/zio/dynamodb/TestDynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/TestDynamoDBExecutorImpl.scala
@@ -68,7 +68,7 @@ private[dynamodb] final case class TestDynamoDBExecutorImpl private (
       case ScanSome(tableName, limit, _, _, exclusiveStartKey, _, _, _, _)        =>
         fakeScanSome(tableName.value, exclusiveStartKey, Some(limit))
 
-      case ScanAll(tableName, _, maybeLimit, _, _, _, _, _, _)                    =>
+      case ScanAll(tableName, _, maybeLimit, _, _, _, _, _, _, _)                 =>
         fakeScanAll(tableName.value, maybeLimit)
 
       case QuerySome(tableName, limit, _, _, exclusiveStartKey, _, _, _, _, _, _) =>


### PR DESCRIPTION
Adds parallel scanning for the `ScanAll` case class. Generates segment numbers based on an input from the user and uses `forEachPar` to execute them each on their own fiber.

I've got a review with John tomorrow AM. I'll get his input and make modifications based on them. I'm hoping to get some input on better testing for this case.