### PR TITLE
Adding Transactions

### DIFF
--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -812,11 +812,23 @@ object LiveSpec extends DefaultRunnableSpec {
 
               assertM(updateItem1.zip(updateItem2).transaction.execute)(equalTo((None, None)))
             }
-          } @@ failing
+          } @@ failing,
           // TODO
-//            testM ("repeated client request token fails on second try") {
-//              ???
-//            }
+          testM("repeated client request token fails on second try") {
+            withDefaultTable { tableName =>
+              val updateItem = UpdateItem(
+                key = Item(id -> first, number -> 7),
+                tableName = TableName(tableName),
+                updateExpression = UpdateExpression($(name).set(notAdam))
+              )
+
+              val transaction = updateItem.transaction.withClientRequestToken("test-token")
+              for {
+                _ <- transaction.execute
+                _ <- transaction.execute
+              } yield assert(())(isUnit)
+            }
+          } @@ failing
         ),
         suite("transact get items")(
           testM("basic transact get items") {

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -797,6 +797,7 @@ object LiveSpec extends DefaultRunnableSpec {
 //              ???
 //            }
         ),
+        // need batch gets that include missing items across tables
         suite("transact get items")(
           testM("basic transact get items") {
             withDefaultTable { tableName =>

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -666,14 +666,15 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("put item") {
             withDefaultTable { tableName =>
               val putItem = TransactWriteItems.Put(
-                item = ???,
+                item = Item(id -> first, name -> avi3, number -> 10),
                 tableName = TableName(tableName)
               )
               for {
                 _ <- TransactWriteItems(
                        transactions = Chunk(putItem)
                      ).execute
-              } yield assertCompletes
+                written <- getItem(tableName, PrimaryKey(id -> first, number -> 10)).execute
+              } yield assert(written)(isSome)
             }
           },
           testM("condition check") {

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -84,21 +84,11 @@ object LiveSpec extends DefaultRunnableSpec {
   private val john2Item = Item(id -> third, name -> john2, number -> 6)
   private val john3Item = Item(id -> third, name -> john3, number -> 9)
 
-  private def pk(item: Item): PrimaryKey = {
-    val map: ScalaMap[Item, PrimaryKey] = ScalaMap(
-      aviItem   -> PrimaryKey(id -> first, number -> 1),
-      avi2Item  -> PrimaryKey(id -> first, number -> 4),
-      avi3Item  -> PrimaryKey(id -> first, number -> 7),
-      adamItem  -> PrimaryKey(id -> second, number -> 2),
-      adam2Item -> PrimaryKey(id -> second, number -> 5),
-      adam3Item -> PrimaryKey(id -> second, number -> 8),
-      johnItem  -> PrimaryKey(id -> third, number -> 3),
-      john2Item -> PrimaryKey(id -> third, number -> 6),
-      john3Item -> PrimaryKey(id -> third, number -> 9)
-    )
-    map.getOrElse(item, PrimaryKey("nothing" -> "nothing"))
-
-  }
+  private def pk(item: Item): PrimaryKey =
+    (item.map.get("id"), item.map.get("num")) match {
+      case (Some(id), Some(num)) => PrimaryKey("id" -> id, "num" -> num)
+      case _                     => throw new IllegalStateException(s"Both id and num need to present in item $item")
+    }
 
   private def insertData(tableName: String) =
     putItem(tableName, aviItem) *>

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -807,6 +807,34 @@ object LiveSpec extends DefaultRunnableSpec {
 //          testM("repeated client request token fails on second try") {
 //            ???
 //          }
+        ),
+        suite("transact get items")(
+          testM("basic transact get items") {
+            withDefaultTable { tableName =>
+              val getItem = TransactGetItems(
+                Chunk(
+                  GetItem(TableName(tableName), Item(id -> first, number -> 7)),
+                  GetItem(TableName(tableName), Item(id -> second, number -> 5))
+                )
+              )
+              for {
+                a <- getItem.execute
+              } yield assert(a)(equalTo(Chunk(Some(avi3Item), Some(adam2Item))))
+            }
+          },
+          testM("single failure means complete failure") {
+            withDefaultTable { tableName =>
+              val getItem = TransactGetItems(
+                Chunk(
+                  GetItem(TableName(tableName), Item(id -> first, number -> 1000)),
+                  GetItem(TableName(tableName), Item(id -> second, number -> 5))
+                )
+              )
+              for {
+                a <- getItem.execute
+              } yield assert(a)(equalTo(Chunk()))
+            }
+          } @@ failing
         )
       )
     )

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -523,34 +523,30 @@ object LiveSpec extends DefaultRunnableSpec {
             }
           },
           testM("append to list") {
-            withDefaultTable {
-              tableName =>
-                for {
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").setValue(List(1))).execute
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").appendList(Chunk(2, 3, 4))).execute
-                  updated <- getItem(tableName, secondPrimaryKey).execute
-                } yield assert(
-                  updated.map(a =>
-                    a.get("listThing")(
-                      FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
-                    )
+            withDefaultTable { tableName =>
+              for {
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").setValue(List(1))).execute
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").appendList(Chunk(2, 3, 4))).execute
+                updated <- getItem(tableName, secondPrimaryKey).execute
+              } yield assert(
+                updated.map(a =>
+                  a.get("listThing")(
+                    FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
                   )
                 )
               )(equalTo(Some(Right(List(1, 2, 3, 4)))))
             }
           },
           testM("prepend to list") {
-            withDefaultTable {
-              tableName =>
-                for {
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").setValue(List(1))).execute
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").prependList(Chunk(-1, 0))).execute
-                  updated <- getItem(tableName, secondPrimaryKey).execute
-                } yield assert(
-                  updated.map(a =>
-                    a.get("listThing")(
-                      FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
-                    )
+            withDefaultTable { tableName =>
+              for {
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").setValue(List(1))).execute
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").prependList(Chunk(-1, 0))).execute
+                updated <- getItem(tableName, secondPrimaryKey).execute
+              } yield assert(
+                updated.map(a =>
+                  a.get("listThing")(
+                    FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
                   )
                 )
               )(equalTo(Some(Right(List(-1, 0, 1)))))
@@ -758,7 +754,7 @@ object LiveSpec extends DefaultRunnableSpec {
               val updateItem = UpdateItem(
                 key = Item(id -> first, number -> 7),
                 tableName = TableName(tableName),
-                updateExpression = UpdateExpression($(name).set(notAdam))
+                updateExpression = UpdateExpression($(name).setValue(notAdam))
               )
               for {
                 _ <- updateItem.transaction.execute
@@ -783,7 +779,7 @@ object LiveSpec extends DefaultRunnableSpec {
               val updateItem     = UpdateItem(
                 key = Item(id -> first, number -> 7),
                 tableName = TableName(tableName),
-                updateExpression = UpdateExpression($(name).set(notAdam))
+                updateExpression = UpdateExpression($(name).setValue(notAdam))
               )
               val deleteItem     = DeleteItem(
                 key = Item(id -> first, number -> 4),

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -502,35 +502,33 @@ object LiveSpec extends DefaultRunnableSpec {
             }
           },
           testM("append to list") {
-            withDefaultTable {
-              tableName =>
-                for {
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").set(List(1))).execute
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").appendList(Chunk(2, 3, 4))).execute
-                  updated <- getItem(tableName, secondPrimaryKey).execute
-                } yield assert(
-                  updated.map(a =>
-                    a.get("listThing")(
-                      FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
-                    )
+            withDefaultTable { tableName =>
+              for {
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").set(List(1))).execute
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").appendList(Chunk(2, 3, 4))).execute
+                updated <- getItem(tableName, secondPrimaryKey).execute
+              } yield assert(
+                updated.map(a =>
+                  a.get("listThing")(
+                    FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
                   )
-                )(equalTo(Some(Right(List(1, 2, 3, 4)))))
+                )
+              )(equalTo(Some(Right(List(1, 2, 3, 4)))))
             }
           },
           testM("prepend to list") {
-            withDefaultTable {
-              tableName =>
-                for {
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").set(List(1))).execute
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").prependList(Chunk(-1, 0))).execute
-                  updated <- getItem(tableName, secondPrimaryKey).execute
-                } yield assert(
-                  updated.map(a =>
-                    a.get("listThing")(
-                      FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
-                    )
+            withDefaultTable { tableName =>
+              for {
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").set(List(1))).execute
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").prependList(Chunk(-1, 0))).execute
+                updated <- getItem(tableName, secondPrimaryKey).execute
+              } yield assert(
+                updated.map(a =>
+                  a.get("listThing")(
+                    FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
                   )
-                )(equalTo(Some(Right(List(-1, 0, 1)))))
+                )
+              )(equalTo(Some(Right(List(-1, 0, 1)))))
             }
           },
           testM("set an Item Attribute") {
@@ -662,6 +660,32 @@ object LiveSpec extends DefaultRunnableSpec {
               } yield assert(updated)(equalTo(Some(Item(id -> 1, number -> -2))))
           )
         }
+      ),
+      suite("transactions")(
+        suite("transact write items")(
+          testM("put item") {
+            withDefaultTable { tableName =>
+              val putItem = TransactWriteItems.Put(
+                item = ???,
+                tableName = TableName(tableName)
+              )
+              for {
+                _ <- TransactWriteItems(
+                       transactions = Chunk(putItem)
+                     ).execute
+              } yield assertCompletes
+            }
+          },
+          testM("condition check") {
+            ???
+          },
+          testM("delete item") {
+            ???
+          },
+          testM("update item") {
+            ???
+          }
+        )
       )
     )
       .provideSomeLayerShared[TestEnvironment](

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -156,7 +156,7 @@ object LiveSpec extends DefaultRunnableSpec {
   private def assertDynamoDbException(substring: String): Assertion[Any] =
     isSubtype[DynamoDbException](hasMessage(containsString(substring)))
 
-  private val trueConditionExpression = ConditionExpression.Equals(
+  private val conditionAlwaysTrue = ConditionExpression.Equals(
     ConditionExpression.Operand.ValueOperand(AttributeValue(id)),
     ConditionExpression.Operand.ValueOperand(AttributeValue(id))
   )
@@ -715,7 +715,7 @@ object LiveSpec extends DefaultRunnableSpec {
               val conditionCheck = ConditionCheck(
                 primaryKey = pk(avi3Item),
                 tableName = TableName(tableName),
-                conditionExpression = trueConditionExpression
+                conditionExpression = conditionAlwaysTrue
               )
               val putItem        = PutItem(
                 item = Item(id -> first, name -> avi3, number -> 10),
@@ -782,7 +782,7 @@ object LiveSpec extends DefaultRunnableSpec {
               val conditionCheck = ConditionCheck(
                 primaryKey = pk(aviItem),
                 tableName = TableName(tableName),
-                conditionExpression = trueConditionExpression
+                conditionExpression = conditionAlwaysTrue
               )
               val updateItem     = UpdateItem(
                 key = pk(avi3Item),

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -818,7 +818,6 @@ object LiveSpec extends DefaultRunnableSpec {
 //              ???
 //            }
         ),
-        // need batch gets that include missing items across tables
         suite("transact get items")(
           testM("basic transact get items") {
             withDefaultTable { tableName =>

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -788,8 +788,19 @@ object LiveSpec extends DefaultRunnableSpec {
                 tableName = TableName(tableName),
                 updateExpression = UpdateExpression($(name).set("shouldFail"))
               )
+
+              val transaction = updateItem1.zip(updateItem2).transaction
+
               for {
-                a <- updateItem1.zip(updateItem2).transaction.execute
+                (actions, _)    <- DynamoDBExecutorImpl.buildTransaction(transaction)
+                builtTransaction =
+                  DynamoDBExecutorImpl.constructTransaction(actions, DynamoDBExecutorImpl.TransactionType.Write)
+
+                _                = println(s"""
+                               |actions: $actions
+                               |builtTransaction: $builtTransaction
+                               |""".stripMargin)
+                a               <- transaction.execute
               } yield assert(a)(equalTo((None, None)))
             }
           } @@ failing

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -802,7 +802,10 @@ object LiveSpec extends DefaultRunnableSpec {
                 a <- TransactWriteItems(transactions = Chunk(updateItem1, updateItem2)).execute
               } yield assert(a)(isUnit)
             }
-          } @@ failing
+          } @@ failing,
+          testM("repeated client request token fails on second try") {
+            ???
+          }
         )
       )
     )

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -789,19 +789,7 @@ object LiveSpec extends DefaultRunnableSpec {
                 updateExpression = UpdateExpression($(name).set("shouldFail"))
               )
 
-              val transaction = updateItem1.zip(updateItem2).transaction
-
-              for {
-                (actions, _)    <- DynamoDBExecutorImpl.buildTransaction(transaction)
-                builtTransaction =
-                  DynamoDBExecutorImpl.constructTransaction(actions, DynamoDBExecutorImpl.TransactionType.Write)
-
-                _                = println(s"""
-                               |actions: $actions
-                               |builtTransaction: $builtTransaction
-                               |""".stripMargin)
-                a               <- transaction.execute
-              } yield assert(a)(equalTo((None, None)))
+              assertM(updateItem1.zip(updateItem2).transaction.execute)(equalTo((None, None)))
             }
           } @@ failing
           // TODO

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -802,10 +802,11 @@ object LiveSpec extends DefaultRunnableSpec {
                 a <- TransactWriteItems(transactions = Chunk(updateItem1, updateItem2)).execute
               } yield assert(a)(isUnit)
             }
-          } @@ failing,
-          testM("repeated client request token fails on second try") {
-            ???
-          }
+          } @@ failing
+          // TODO
+//          testM("repeated client request token fails on second try") {
+//            ???
+//          }
         )
       )
     )

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -16,6 +16,7 @@ import zio.dynamodb.ProjectionExpression._
 import zio.test.Assertion._
 import zio.test.environment._
 import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.model.{ DynamoDbException, IdempotentParameterMismatchException }
 import zio.schema.{ DeriveSchema, Schema }
 import zio.stream.{ ZSink, ZStream }
 import zio.test._
@@ -45,14 +46,12 @@ object LiveSpec extends DefaultRunnableSpec {
       .identity[Has[Clock.Service]]) >>> DynamoDBExecutor.live) ++ (ZLayer
       .identity[Has[Blocking.Service]] >>> LocalDdbServer.inMemoryLayer)
 
-  private val id       = "id"
-  private val first    = "first"
-  private val second   = "second"
-  private val third    = "third"
-  private val name     = "firstName"
-  private val number   = "num"
-  val secondPrimaryKey = PrimaryKey(id -> second, number -> 2)
-
+  private val id      = "id"
+  private val first   = "first"
+  private val second  = "second"
+  private val third   = "third"
+  private val name    = "firstName"
+  private val number  = "num"
   private val notAdam = "notAdam"
   private val avi     = "avi"
   private val avi2    = "avi2"
@@ -84,6 +83,22 @@ object LiveSpec extends DefaultRunnableSpec {
   private val johnItem  = Item(id -> third, name -> john, number -> 3)
   private val john2Item = Item(id -> third, name -> john2, number -> 6)
   private val john3Item = Item(id -> third, name -> john3, number -> 9)
+
+  private def pk(item: Item): PrimaryKey = {
+    val map: ScalaMap[Item, PrimaryKey] = ScalaMap(
+      aviItem   -> PrimaryKey(id -> first, number -> 1),
+      avi2Item  -> PrimaryKey(id -> first, number -> 4),
+      avi3Item  -> PrimaryKey(id -> first, number -> 7),
+      adamItem  -> PrimaryKey(id -> second, number -> 2),
+      adam2Item -> PrimaryKey(id -> second, number -> 5),
+      adam3Item -> PrimaryKey(id -> second, number -> 8),
+      johnItem  -> PrimaryKey(id -> third, number -> 3),
+      john2Item -> PrimaryKey(id -> third, number -> 6),
+      john3Item -> PrimaryKey(id -> third, number -> 9)
+    )
+    map.getOrElse(item, PrimaryKey("nothing" -> "nothing"))
+
+  }
 
   private def insertData(tableName: String) =
     putItem(tableName, aviItem) *>
@@ -138,6 +153,14 @@ object LiveSpec extends DefaultRunnableSpec {
       } yield result
     }
 
+  private def assertDynamoDbException(substring: String): Assertion[Any] =
+    isSubtype[DynamoDbException](hasMessage(containsString(substring)))
+
+  private val trueConditionExpression = ConditionExpression.Equals(
+    ConditionExpression.Operand.ValueOperand(AttributeValue(id)),
+    ConditionExpression.Operand.ValueOperand(AttributeValue(id))
+  )
+
   override def spec: ZSpec[TestEnvironment, Any] =
     suite("live test")(
       suite("basic usage")(
@@ -184,7 +207,7 @@ object LiveSpec extends DefaultRunnableSpec {
         },
         testM("get into case class") {
           withDefaultTable { tableName =>
-            get[Person](tableName, secondPrimaryKey).execute.map(person =>
+            get[Person](tableName, pk(adamItem)).execute.map(person =>
               assert(person)(equalTo(Right(Person("second", "adam", 2))))
             )
           }
@@ -192,7 +215,7 @@ object LiveSpec extends DefaultRunnableSpec {
         testM("get data from map") {
           withDefaultTable { tableName =>
             for {
-              item <- getItem(tableName, PrimaryKey(id -> first, number -> 1), $(id), $(number), $("mapp.abc")).execute
+              item <- getItem(tableName, pk(aviItem), $(id), $(number), $("mapp.abc")).execute
             } yield assert(item)(equalTo(Some(Item(id -> first, number -> 1, "mapp" -> ScalaMap("abc" -> 1)))))
           }
         },
@@ -204,11 +227,11 @@ object LiveSpec extends DefaultRunnableSpec {
         testM("batch get item") {
           withDefaultTable { tableName =>
             val getItems = BatchGetItem().addAll(
-              GetItem(TableName(tableName), Item(id -> first, number -> 7)),
-              GetItem(TableName(tableName), Item(id -> second, number -> 5))
+              GetItem(TableName(tableName), pk(avi3Item)),
+              GetItem(TableName(tableName), pk(adam2Item))
             )
             for {
-              a <- getItems.transaction.execute
+              a <- getItems.execute
             } yield assert(a)(
               equalTo(
                 BatchGetItem.Response(
@@ -441,11 +464,8 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("update name") {
             withDefaultTable { tableName =>
               for {
-                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).setValue(notAdam)).execute
-                updated         <- getItem(
-                                     tableName,
-                                     secondPrimaryKey
-                                   ).execute
+                updatedResponse <- updateItem(tableName, pk(adamItem))($(name).setValue(notAdam)).execute
+                updated         <- getItem(tableName, pk(adamItem)).execute
               } yield assert(updated)(equalTo(Some(Item(name -> notAdam, id -> second, number -> 2)))) && assert(
                 updatedResponse
               )(isNone)
@@ -454,13 +474,10 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("update name return updated old") {
             withDefaultTable { tableName =>
               for {
-                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).setValue(notAdam))
+                updatedResponse <- updateItem(tableName, pk(adamItem))($(name).setValue(notAdam))
                                      .returns(ReturnValues.UpdatedOld)
                                      .execute
-                updated         <- getItem(
-                                     tableName,
-                                     secondPrimaryKey
-                                   ).execute
+                updated         <- getItem(tableName, pk(adamItem)).execute
               } yield assert(updated)(equalTo(Some(Item(name -> notAdam, id -> second, number -> 2)))) &&
                 assert(updatedResponse)(equalTo(Some(Item(name -> adam))))
             }
@@ -468,13 +485,10 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("update name return all old") {
             withDefaultTable { tableName =>
               for {
-                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).setValue(notAdam))
+                updatedResponse <- updateItem(tableName, pk(adamItem))($(name).setValue(notAdam))
                                      .returns(ReturnValues.AllOld)
                                      .execute
-                updated         <- getItem(
-                                     tableName,
-                                     secondPrimaryKey
-                                   ).execute
+                updated         <- getItem(tableName, pk(adamItem)).execute
               } yield assert(updated)(equalTo(Some(Item(name -> notAdam, id -> second, number -> 2)))) &&
                 assert(updatedResponse)(equalTo(Some(adamItem)))
             }
@@ -483,12 +497,12 @@ object LiveSpec extends DefaultRunnableSpec {
             withDefaultTable { tableName =>
               val updatedItem = Some(Item(name -> notAdam, id -> second, number -> 2))
               for {
-                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).setValue(notAdam))
+                updatedResponse <- updateItem(tableName, pk(adamItem))($(name).setValue(notAdam))
                                      .returns(ReturnValues.AllNew)
                                      .execute
                 updated         <- getItem(
                                      tableName,
-                                     secondPrimaryKey
+                                     pk(adamItem)
                                    ).execute
               } yield assert(updated)(equalTo(updatedItem)) &&
                 assert(updatedResponse)(equalTo(updatedItem))
@@ -497,12 +511,12 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("update name return updated new") {
             withDefaultTable { tableName =>
               for {
-                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).setValue(notAdam))
+                updatedResponse <- updateItem(tableName, pk(adamItem))($(name).setValue(notAdam))
                                      .returns(ReturnValues.UpdatedNew)
                                      .execute
                 updated         <- getItem(
                                      tableName,
-                                     secondPrimaryKey
+                                     pk(adamItem)
                                    ).execute
               } yield assert(updated)(equalTo(Some(Item(name -> notAdam, id -> second, number -> 2)))) &&
                 assert(updatedResponse)(equalTo(Some(Item(name -> notAdam))))
@@ -511,11 +525,11 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("insert item into list") {
             withDefaultTable { tableName =>
               for {
-                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").setValue(List(1))).execute
-                _       <- updateItem(tableName, secondPrimaryKey)($("listThing[1]").setValue(2)).execute
+                _       <- updateItem(tableName, pk(adamItem))($("listThing").setValue(List(1))).execute
+                _       <- updateItem(tableName, pk(adamItem))($("listThing[1]").setValue(2)).execute
                 updated <- getItem(
                              tableName,
-                             secondPrimaryKey
+                             pk(adamItem)
                            ).execute
               } yield assert(updated)(
                 equalTo(Some(Item(id -> second, number -> 2, name -> adam, "listThing" -> List(1, 2))))
@@ -525,9 +539,9 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("append to list") {
             withDefaultTable { tableName =>
               for {
-                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").setValue(List(1))).execute
-                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").appendList(Chunk(2, 3, 4))).execute
-                updated <- getItem(tableName, secondPrimaryKey).execute
+                _       <- updateItem(tableName, pk(adamItem))($("listThing").setValue(List(1))).execute
+                _       <- updateItem(tableName, pk(adamItem))($("listThing").appendList(Chunk(2, 3, 4))).execute
+                updated <- getItem(tableName, pk(adamItem)).execute
               } yield assert(
                 updated.map(a =>
                   a.get("listThing")(
@@ -540,9 +554,9 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("prepend to list") {
             withDefaultTable { tableName =>
               for {
-                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").setValue(List(1))).execute
-                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").prependList(Chunk(-1, 0))).execute
-                updated <- getItem(tableName, secondPrimaryKey).execute
+                _       <- updateItem(tableName, pk(adamItem))($("listThing").setValue(List(1))).execute
+                _       <- updateItem(tableName, pk(adamItem))($("listThing").prependList(Chunk(-1, 0))).execute
+                updated <- getItem(tableName, pk(adamItem)).execute
               } yield assert(
                 updated.map(a =>
                   a.get("listThing")(
@@ -555,10 +569,10 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("set an Item Attribute") {
             withDefaultTable { tableName =>
               for {
-                _       <- updateItem(tableName, secondPrimaryKey)($(name).set($(id))).execute
+                _       <- updateItem(tableName, pk(adamItem))($(name).set($(id))).execute
                 updated <- getItem(
                              tableName,
-                             secondPrimaryKey
+                             pk(adamItem)
                            ).execute
               } yield assert(updated)(
                 equalTo(Some(Item(id -> second, number -> 2, name -> second)))
@@ -600,10 +614,10 @@ object LiveSpec extends DefaultRunnableSpec {
         testM("remove field") {
           withDefaultTable { tableName =>
             for {
-              _       <- updateItem(tableName, secondPrimaryKey)($(name).remove).execute
+              _       <- updateItem(tableName, pk(adamItem))($(name).remove).execute
               updated <- getItem(
                            tableName,
-                           secondPrimaryKey
+                           pk(adamItem)
                          ).execute
             } yield assert(updated)(equalTo(Some(Item(id -> second, number -> 2))))
           }
@@ -693,18 +707,15 @@ object LiveSpec extends DefaultRunnableSpec {
               for {
                 _ <- putItem.transaction.execute
                 written <- getItem(tableName, PrimaryKey(id -> first, number -> 10)).execute
-              } yield assert(written)(isSome)
+              } yield assert(written)(isSome(equalTo(putItem.item)))
             }
           },
           testM("condition check succeeds") {
             withDefaultTable { tableName =>
               val conditionCheck = ConditionCheck(
-                primaryKey = PrimaryKey(id -> first, number -> 7),
+                primaryKey = pk(avi3Item),
                 tableName = TableName(tableName),
-                conditionExpression = ConditionExpression.Equals(
-                  ConditionExpression.Operand.ValueOperand(AttributeValue(id)),
-                  ConditionExpression.Operand.ValueOperand(AttributeValue(id))
-                )
+                conditionExpression = trueConditionExpression
               )
               val putItem        = PutItem(
                 item = Item(id -> first, name -> avi3, number -> 10),
@@ -717,10 +728,10 @@ object LiveSpec extends DefaultRunnableSpec {
               } yield assert(written)(isSome)
             }
           },
-          testM("condition check fails") {
+          testM("condition check fails because 'id' != 'first'") {
             withDefaultTable { tableName =>
               val conditionCheck = ConditionCheck(
-                primaryKey = PrimaryKey(id -> first, number -> 8),
+                primaryKey = pk(avi3Item),
                 tableName = TableName(tableName),
                 conditionExpression = ConditionExpression.Equals(
                   ConditionExpression.Operand.ValueOperand(AttributeValue(id)),
@@ -733,18 +744,18 @@ object LiveSpec extends DefaultRunnableSpec {
               )
 
               assertM(
-                conditionCheck.zip(putItem).transaction.execute
-              )(isUnit)
+                conditionCheck.zip(putItem).transaction.execute.run
+              )(fails(assertDynamoDbException("ConditionalCheckFailed")))
             }
-          } @@ failing,
+          },
           testM("delete item") {
             withDefaultTable { tableName =>
               val deleteItem = DeleteItem(
-                key = Item(id -> first, number -> 7),
+                key = pk(avi3Item),
                 tableName = TableName(tableName)
               )
               for {
-                _ <- deleteItem.transaction.execute
+                _       <- deleteItem.transaction.execute
                 written <- getItem(tableName, PrimaryKey(id -> first, number -> 7)).execute
               } yield assert(written)(isNone)
             }
@@ -752,13 +763,13 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("update item") {
             withDefaultTable { tableName =>
               val updateItem = UpdateItem(
-                key = Item(id -> first, number -> 7),
+                key = pk(avi3Item),
                 tableName = TableName(tableName),
                 updateExpression = UpdateExpression($(name).setValue(notAdam))
               )
               for {
-                _ <- updateItem.transaction.execute
-                written <- get[Person](tableName, PrimaryKey(id -> first, number -> 7)).execute
+                _       <- updateItem.transaction.execute
+                written <- get[Person](tableName, pk(avi3Item)).execute
               } yield assert(written)(isRight(equalTo(Person(first, notAdam, 7))))
             }
           },
@@ -769,20 +780,17 @@ object LiveSpec extends DefaultRunnableSpec {
                 tableName = TableName(tableName)
               )
               val conditionCheck = ConditionCheck(
-                primaryKey = PrimaryKey(id -> first, number -> 1),
+                primaryKey = pk(aviItem),
                 tableName = TableName(tableName),
-                conditionExpression = ConditionExpression.Equals(
-                  ConditionExpression.Operand.ValueOperand(AttributeValue(id)),
-                  ConditionExpression.Operand.ValueOperand(AttributeValue(id))
-                )
+                conditionExpression = trueConditionExpression
               )
               val updateItem     = UpdateItem(
-                key = Item(id -> first, number -> 7),
+                key = pk(avi3Item),
                 tableName = TableName(tableName),
                 updateExpression = UpdateExpression($(name).setValue(notAdam))
               )
               val deleteItem     = DeleteItem(
-                key = Item(id -> first, number -> 4),
+                key = pk(avi2Item),
                 tableName = TableName(tableName)
               )
 
@@ -799,43 +807,53 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("two updates to same item fails") {
             withDefaultTable { tableName =>
               val updateItem1 = UpdateItem(
-                key = Item(id -> first, number -> 7),
+                key = pk(avi3Item),
                 tableName = TableName(tableName),
-                updateExpression = UpdateExpression($(name).set(notAdam))
+                updateExpression = UpdateExpression($(name).setValue("abc"))
               )
 
               val updateItem2 = UpdateItem(
-                key = Item(id -> first, number -> 7),
+                key = pk(avi3Item),
                 tableName = TableName(tableName),
-                updateExpression = UpdateExpression($(name).set("shouldFail"))
+                updateExpression = UpdateExpression($(name).setValue("shouldFail"))
               )
 
-              assertM(updateItem1.zip(updateItem2).transaction.execute)(equalTo((None, None)))
+              assertM(updateItem1.zip(updateItem2).transaction.execute.run)(
+                fails(assertDynamoDbException("Transaction request cannot include multiple operations on one item"))
+              )
             }
-          } @@ failing,
-          // TODO
-          testM("repeated client request token fails on second try") {
+          },
+          testM("repeated client request token with different transaction fails") {
             withDefaultTable { tableName =>
               val updateItem = UpdateItem(
-                key = Item(id -> first, number -> 7),
+                key = pk(avi3Item),
                 tableName = TableName(tableName),
-                updateExpression = UpdateExpression($(name).set(notAdam))
-              )
+                updateExpression = UpdateExpression($(name).setValue(notAdam))
+              ).transaction.withClientRequestToken("test-token")
 
-              val transaction = updateItem.transaction.withClientRequestToken("test-token")
-              for {
-                _ <- transaction.execute
-                _ <- transaction.execute
-              } yield assert(())(isUnit)
+              val updateItem2 = UpdateItem(
+                key = pk(avi3Item),
+                tableName = TableName(tableName),
+                updateExpression = UpdateExpression($(name).setValue("BOOOOOOO"))
+              ).transaction.withClientRequestToken("test-token")
+
+              val program = for {
+                _ <- updateItem.execute
+                _ <- updateItem2.execute
+              } yield ()
+
+              assertM(program.run)(
+                fails(isSubtype[IdempotentParameterMismatchException](Assertion.anything))
+              )
             }
-          } @@ failing
+          }
         ),
         suite("transact get items")(
           testM("basic transact get items") {
             withDefaultTable { tableName =>
               val getItems =
-                GetItem(TableName(tableName), Item(id -> first, number -> 7))
-                  .zip(GetItem(TableName(tableName), Item(id -> second, number -> 5)))
+                GetItem(TableName(tableName), pk(avi3Item))
+                  .zip(GetItem(TableName(tableName), pk(adam2Item)))
               for {
                 a <- getItems.transaction.execute
               } yield assert(a)(equalTo((Some(avi3Item), Some(adam2Item))))
@@ -844,8 +862,8 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("basic batch get item transaction") {
             withDefaultTable { tableName =>
               val getItems = BatchGetItem().addAll(
-                GetItem(TableName(tableName), Item(id -> first, number -> 7)),
-                GetItem(TableName(tableName), Item(id -> second, number -> 5))
+                GetItem(TableName(tableName), pk(avi3Item)),
+                GetItem(TableName(tableName), pk(adam2Item))
               )
               for {
                 a <- getItems.transaction.execute
@@ -866,7 +884,7 @@ object LiveSpec extends DefaultRunnableSpec {
             withDefaultTable { tableName =>
               val getItems =
                 GetItem(TableName(tableName), Item(id -> first, number -> 1000))
-                  .zip(GetItem(TableName(tableName), Item(id -> second, number -> 5)))
+                  .zip(GetItem(TableName(tableName), pk(adam2Item)))
               for {
                 a <- getItems.transaction.execute
               } yield assert(a)(equalTo((None, Some(adam2Item))))
@@ -876,8 +894,8 @@ object LiveSpec extends DefaultRunnableSpec {
             withDefaultTable { tableName =>
               val secondTable = numberTable("some-table")
               val getItems    = BatchGetItem().addAll(
-                GetItem(TableName(tableName), Item(id -> first, number -> 7)),
-                GetItem(TableName(tableName), Item(id -> second, number -> 5)),
+                GetItem(TableName(tableName), pk(avi3Item)),
+                GetItem(TableName(tableName), pk(adam2Item)),
                 GetItem(TableName("some-table"), Item(id -> 5))
               )
               for {

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -85,6 +85,7 @@ private[dynamodb] final case class DynamoDBExecutorImpl private (clock: Clock.Se
       case c: TransactWriteItems => executeTransactWriteItems(c)
       case c: TransactGetItems   => executeTransactGetItems(c)
       case Succeed(c)            => ZIO.succeed(c())
+      // match on the FailCause => ZIO.failCause(c.cause())
     }
 
   override def execute[A](atomicQuery: DynamoDBQuery[A]): ZIO[Any, Throwable, A] =

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -391,9 +391,9 @@ private[dynamodb] final case class DynamoDBExecutorImpl private (clock: Clock.Se
                                                         items    <- response.responses.map(_.map(item => item.itemValue.map(dynamoDBItem)))
                                                       } yield Chunk.fromIterable(items)).mapError(_.toThrowable)
                                                     case Right(transactWriteItems) =>
-                                                      for {
-                                                        _ <- dynamoDb.transactWriteItems(transactWriteItems).mapError(_.toThrowable)
-                                                      } yield Chunk.fill(transactionActions.length)(())
+                                                      dynamoDb
+                                                        .transactWriteItems(transactWriteItems)
+                                                        .mapBoth(_.toThrowable, _ => Chunk.fill(transactionActions.length)(()))
                                                   }
     } yield transactionMapping(a)
 

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -171,7 +171,7 @@ private[dynamodb] final case class DynamoDBExecutorImpl private (clock: Clock.Se
         unprocessed <- ref.get
       } yield BatchWriteItem.Response(unprocessed.toOption)
 
-  // Need to go through the chunk and make sure we don't have mixed transaction actions otherwise we'll fail at runtime.
+  // Need to go through the chunk and make sure we don't have mixed transaction actions
   private def filterMixedTransactions[A](
     actions: Chunk[Constructor[A]]
   ): Either[Throwable, (Chunk[Constructor[A]], TransactionType)] =

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -78,7 +78,7 @@ private[dynamodb] final case class DynamoDBExecutorImpl private (clock: Clock.Se
       case describeTable: DescribeTable           => doDescribeTable(describeTable)
       case querySome: QuerySome                   => doQuerySome(querySome)
       case queryAll: QueryAll                     => doQueryAll(queryAll)
-      case transactWriteItems: TransactWriteItems => ???
+      case transactWriteItems: TransactWriteItems => doTransactWriteItems(transactWriteItems)
       case Succeed(thunk)                         => ZIO.succeed(thunk())
     }
 
@@ -461,7 +461,7 @@ case object DynamoDBExecutorImpl {
 
   private def generateZIOAWSTransactWriteItems(transactWriteItems: TransactWriteItems): TransactWriteItemsRequest =
     TransactWriteItemsRequest(
-      transactItems = transactWriteItems.transactions.map(_ => ???),
+      transactItems = transactWriteItems.transactions.map(generateTransactWriteItem),
       returnConsumedCapacity = Some(buildAwsReturnConsumedCapacity(transactWriteItems.capacity)),
       returnItemCollectionMetrics = Some(buildAwsItemMetrics(transactWriteItems.itemMetrics)),
       clientRequestToken = transactWriteItems.clientRequestToken

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -426,7 +426,7 @@ case object DynamoDBExecutorImpl {
     )
   }
 
-  private def constructWriteTransaction[A](actions: Chunk[Constructor[A]]): TransactWriteItemsRequest = {
+  private[dynamodb] def constructWriteTransaction[A](actions: Chunk[Constructor[A]]): TransactWriteItemsRequest = {
     val writeActions: Chunk[TransactWriteItem] = actions.flatMap {
       case s: DeleteItem     => awsTransactWriteItem(s)
       case s: PutItem        => awsTransactWriteItem(s)

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -69,6 +69,7 @@ private[dynamodb] final case class DynamoDBExecutorImpl private (clock: Clock.Se
       case putItem: PutItem                       => doPutItem(putItem)
       case batchGetItem: BatchGetItem             => doBatchGetItem(batchGetItem).provide(Has(clock))
       case batchWriteItem: BatchWriteItem         => doBatchWriteItem(batchWriteItem).provide(Has(clock))
+      case _: ConditionCheck                      => ZIO.unit
       case scanAll: ScanAll                       => doScanAll(scanAll)
       case scanSome: ScanSome                     => doScanSome(scanSome)
       case updateItem: UpdateItem                 => doUpdateItem(updateItem)

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -371,7 +371,7 @@ case object DynamoDBExecutorImpl {
       case TransactionType.Get   => Left(constructGetTransaction(actions))
     }
 
-  private def constructGetTransaction[A](actions: Chunk[Constructor[A]]): TransactGetItemsRequest = {
+  private[dynamodb] def constructGetTransaction[A](actions: Chunk[Constructor[A]]): TransactGetItemsRequest = {
     val getActions: Chunk[TransactGetItem] = actions.flatMap {
       case s: GetItem      =>
         Some(
@@ -731,10 +731,12 @@ case object DynamoDBExecutorImpl {
   ): String =
     projectionExpressions.mkString(", ")
 
-  private def awsAttributeValueMap(attrMap: ScalaMap[String, AttributeValue]): ScalaMap[String, ZIOAwsAttributeValue] =
+  private[dynamodb] def awsAttributeValueMap(
+    attrMap: ScalaMap[String, AttributeValue]
+  ): ScalaMap[String, ZIOAwsAttributeValue]                                                              =
     attrMap.map { case (k, v) => (k, awsAttributeValue(v)) }
 
-  private def awsAttrValToAttrVal(attributeValue: ZIOAwsAttributeValue.ReadOnly): Option[AttributeValue]              =
+  private def awsAttrValToAttrVal(attributeValue: ZIOAwsAttributeValue.ReadOnly): Option[AttributeValue] =
     attributeValue.sValue
       .map(AttributeValue.String)
       .orElse {

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -332,7 +332,7 @@ case object DynamoDBExecutorImpl {
               (
                 Chunk(s),
                 chunk => {
-                  val maybeItem = chunk(0).asInstanceOf[Option[Item]] // may have an empty AttrMap
+                  val maybeItem = chunk(0).asInstanceOf[Option[AttrMap]] // may have an empty AttrMap
                   maybeItem.flatMap(item => if (item.map.isEmpty) None else Some(item)).asInstanceOf[A]
                 }
               )

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -605,7 +605,7 @@ object DynamoDBQuery {
     final case class ConditionCheck(
       primaryKey: PrimaryKey,
       tableName: TableName,
-      conditionExpression: Option[ConditionExpression] = None
+      conditionExpression: ConditionExpression
     ) extends Write
     final case class Put(
       item: AttrMap,

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -596,7 +596,7 @@ object DynamoDBQuery {
     transactions: Chunk[TransactWriteItems.Write],
     capacity: ReturnConsumedCapacity = ReturnConsumedCapacity.None,
     itemMetrics: ReturnItemCollectionMetrics = ReturnItemCollectionMetrics.None,
-    clientRequestToken: Option[String]
+    clientRequestToken: Option[String] = None
   ) extends Constructor[Unit]
 
   private[dynamodb] object TransactWriteItems {
@@ -605,23 +605,23 @@ object DynamoDBQuery {
     final case class ConditionCheck(
       primaryKey: PrimaryKey,
       tableName: TableName,
-      conditionExpression: Option[ConditionExpression]
+      conditionExpression: Option[ConditionExpression] = None
     ) extends Write
     final case class Put(
       item: AttrMap,
       tableName: TableName,
-      conditionExpression: Option[ConditionExpression]
+      conditionExpression: Option[ConditionExpression] = None
     ) extends Write
     final case class Delete(
       primaryKey: PrimaryKey,
       tableName: TableName,
-      conditionExpression: Option[ConditionExpression]
+      conditionExpression: Option[ConditionExpression] = None
     ) extends Write
     final case class Update(
       primaryKey: PrimaryKey,
       tableName: TableName,
       updateExpression: UpdateExpression,
-      conditionExpression: Option[ConditionExpression]
+      conditionExpression: Option[ConditionExpression] = None
     ) extends Write
   }
 
@@ -865,7 +865,7 @@ object DynamoDBQuery {
 
       case Succeed(value)     => (Chunk.empty, _ => value())
 
-      case batchGetItem @ BatchGetItem(_, _, _, _)            =>
+      case batchGetItem @ BatchGetItem(_, _, _, _)             =>
         (
           Chunk(batchGetItem),
           (results: Chunk[Any]) => {
@@ -873,7 +873,7 @@ object DynamoDBQuery {
           }
         )
 
-      case batchWriteItem @ BatchWriteItem(_, _, _, _, _)     =>
+      case batchWriteItem @ BatchWriteItem(_, _, _, _, _)      =>
         (
           Chunk(batchWriteItem),
           (results: Chunk[Any]) => {
@@ -881,7 +881,7 @@ object DynamoDBQuery {
           }
         )
 
-      case deleteTable @ DeleteTable(_)                       =>
+      case deleteTable @ DeleteTable(_)                        =>
         (
           Chunk(deleteTable),
           (results: Chunk[Any]) => {
@@ -889,7 +889,7 @@ object DynamoDBQuery {
           }
         )
 
-      case describeTable @ DescribeTable(_)                   =>
+      case describeTable @ DescribeTable(_)                    =>
         (
           Chunk(describeTable),
           (results: Chunk[Any]) => {
@@ -897,7 +897,7 @@ object DynamoDBQuery {
           }
         )
 
-      case getItem @ GetItem(_, _, _, _, _)                   =>
+      case getItem @ GetItem(_, _, _, _, _)                    =>
         (
           Chunk(getItem),
           (results: Chunk[Any]) => {
@@ -905,7 +905,7 @@ object DynamoDBQuery {
           }
         )
 
-      case putItem @ PutItem(_, _, _, _, _, _)                =>
+      case putItem @ PutItem(_, _, _, _, _, _)                 =>
         (
           Chunk(putItem),
           (results: Chunk[Any]) => {
@@ -913,7 +913,15 @@ object DynamoDBQuery {
           }
         )
 
-      case updateItem @ UpdateItem(_, _, _, _, _, _, _)       =>
+      case transactWriteItems @ TransactWriteItems(_, _, _, _) =>
+        (
+          Chunk(transactWriteItems),
+          (results: Chunk[Any]) => {
+            if (results.isEmpty) ().asInstanceOf[A] else results.head.asInstanceOf[A]
+          }
+        )
+
+      case updateItem @ UpdateItem(_, _, _, _, _, _, _)        =>
         (
           Chunk(updateItem),
           (results: Chunk[Any]) => {
@@ -921,7 +929,7 @@ object DynamoDBQuery {
           }
         )
 
-      case deleteItem @ DeleteItem(_, _, _, _, _, _)          =>
+      case deleteItem @ DeleteItem(_, _, _, _, _, _)           =>
         (
           Chunk(deleteItem),
           (results: Chunk[Any]) => {
@@ -929,7 +937,7 @@ object DynamoDBQuery {
           }
         )
 
-      case scan @ ScanSome(_, _, _, _, _, _, _, _, _)         =>
+      case scan @ ScanSome(_, _, _, _, _, _, _, _, _)          =>
         (
           Chunk(scan),
           (results: Chunk[Any]) => {
@@ -937,7 +945,7 @@ object DynamoDBQuery {
           }
         )
 
-      case scan @ ScanAll(_, _, _, _, _, _, _, _, _, _)       =>
+      case scan @ ScanAll(_, _, _, _, _, _, _, _, _, _)        =>
         (
           Chunk(scan),
           (results: Chunk[Any]) => {
@@ -945,7 +953,7 @@ object DynamoDBQuery {
           }
         )
 
-      case query @ QuerySome(_, _, _, _, _, _, _, _, _, _, _) =>
+      case query @ QuerySome(_, _, _, _, _, _, _, _, _, _, _)  =>
         (
           Chunk(query),
           (results: Chunk[Any]) => {
@@ -953,7 +961,7 @@ object DynamoDBQuery {
           }
         )
 
-      case query @ QueryAll(_, _, _, _, _, _, _, _, _, _, _)  =>
+      case query @ QueryAll(_, _, _, _, _, _, _, _, _, _, _)   =>
         (
           Chunk(query),
           (results: Chunk[Any]) => {
@@ -961,7 +969,7 @@ object DynamoDBQuery {
           }
         )
 
-      case createTable @ CreateTable(_, _, _, _, _, _, _, _)  =>
+      case createTable @ CreateTable(_, _, _, _, _, _, _, _)   =>
         (
           Chunk(createTable),
           (results: Chunk[Any]) => {

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -350,8 +350,9 @@ object DynamoDBQuery {
 
   def succeed[A](a: A): DynamoDBQuery[A] = Succeed(() => a)
 
-  case class FailCause(cause: () => Cause[Throwable]) extends DynamoDBQuery[Nothing]
+  private[dynamodb] final case class FailCause(cause: () => Cause[Throwable]) extends Constructor[Nothing]
   private[dynamodb] def failCause(cause: => Cause[Throwable]): DynamoDBQuery[Nothing] = FailCause(() => cause)
+  final case class EmptyTransaction() extends Throwable
 
   /**
    * Each element in `values` is zipped together using function `body` which has signature `A => DynamoDBQuery[B]`
@@ -612,7 +613,7 @@ object DynamoDBQuery {
     clientRequestToken: Option[String] = None
   ) extends Constructor[A]
 
-  private[dynamodb] final case class MixedTransactionTypes(a: Int = 0) extends Throwable
+  private[dynamodb] final case class MixedTransactionTypes() extends Throwable
   private[dynamodb] final case class InvalidTransactionActions(invalidActions: NonEmptyChunk[DynamoDBQuery[Any]])
       extends Throwable
 

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -687,6 +687,7 @@ object DynamoDBQuery {
     clientRequestToken: Option[String] = None
   ) extends DynamoDBQuery[A]
 
+  private[dynamodb] final case class MixedTransactionTypes(a: Int = 0) extends Throwable
   private[dynamodb] final case class InvalidTransactionActions(invalidActions: NonEmptyChunk[DynamoDBQuery[Any]])
       extends Throwable
 
@@ -1039,6 +1040,14 @@ object DynamoDBQuery {
           Chunk(batchWriteItem),
           (results: Chunk[Any]) => {
             results.head.asInstanceOf[A]
+          }
+        )
+
+      case _: FailCause                                       =>
+        (
+          Chunk[Constructor[Any]](),
+          (_: Chunk[Any]) => {
+            ().asInstanceOf[A]
           }
         )
 

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -1083,13 +1083,11 @@ object DynamoDBQuery {
           }
         )
 
-      case transaction @ Transaction(_, _)                    =>
-        (
-          Chunk(transaction),
-          (results: Chunk[Any]) => {
-            if (results.isEmpty) ().asInstanceOf[A] else results.head.asInstanceOf[A]
-          }
-        )
+      case Transaction(query, _)                              =>
+        parallelize(query) match {
+          case (constructors, assembler) =>
+            (constructors, assembler)
+        }
 
       case updateItem @ UpdateItem(_, _, _, _, _, _, _)       =>
         (

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -615,10 +615,39 @@ object DynamoDBQuery {
 
     def +[A](transaction: TransactWrite[A]): TransactWriteItems =
       transaction match {
-        case _: PutItem        => ???
-        case _: DeleteItem     => ???
-        case _: ConditionCheck => ???
-        case _: UpdateItem     => ???
+        case putItem: PutItem               =>
+          self.copy(transactions =
+            self.transactions :+ TransactWriteItems.Put(
+              item = putItem.item,
+              tableName = putItem.tableName,
+              conditionExpression = putItem.conditionExpression
+            )
+          )
+        case deleteItem: DeleteItem         =>
+          self.copy(transactions =
+            self.transactions :+ TransactWriteItems.Delete(
+              primaryKey = deleteItem.key,
+              tableName = deleteItem.tableName,
+              conditionExpression = deleteItem.conditionExpression
+            )
+          )
+        case conditionCheck: ConditionCheck =>
+          self.copy(transactions =
+            self.transactions :+ TransactWriteItems.ConditionCheck(
+              primaryKey = conditionCheck.primaryKey,
+              tableName = conditionCheck.tableName,
+              conditionExpression = conditionCheck.conditionExpression
+            )
+          )
+        case updateItem: UpdateItem         =>
+          self.copy(transactions =
+            self.transactions :+ TransactWriteItems.Update(
+              primaryKey = updateItem.key,
+              tableName = updateItem.tableName,
+              conditionExpression = updateItem.conditionExpression,
+              updateExpression = updateItem.updateExpression
+            )
+          )
       }
   }
 
@@ -804,7 +833,7 @@ object DynamoDBQuery {
   private[dynamodb] final case class ConditionCheck(
     tableName: TableName,
     primaryKey: PrimaryKey,
-    conditionCheck: ConditionCheck
+    conditionExpression: ConditionExpression
   ) extends TransactWrite[Unit]
 
   private[dynamodb] final case class DeleteItem(

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -591,6 +591,40 @@ object DynamoDBQuery {
     )
   }
 
+  // TODO: These transactions are limited to 25 items
+  private[dynamodb] final case class TransactWriteItems(
+    transactions: Chunk[TransactWriteItems.Write],
+    capacity: ReturnConsumedCapacity = ReturnConsumedCapacity.None,
+    itemMetrics: ReturnItemCollectionMetrics = ReturnItemCollectionMetrics.None,
+    clientRequestToken: Option[String]
+  ) extends Constructor[Unit]
+
+  private[dynamodb] object TransactWriteItems {
+    sealed trait Write
+
+    final case class ConditionCheck(
+      primaryKey: PrimaryKey,
+      tableName: TableName,
+      conditionExpression: Option[ConditionExpression]
+    ) extends Write
+    final case class Put(
+      item: AttrMap,
+      tableName: TableName,
+      conditionExpression: Option[ConditionExpression]
+    ) extends Write
+    final case class Delete(
+      primaryKey: PrimaryKey,
+      tableName: TableName,
+      conditionExpression: Option[ConditionExpression]
+    ) extends Write
+    final case class Update(
+      primaryKey: PrimaryKey,
+      tableName: TableName,
+      updateExpression: UpdateExpression,
+      conditionExpression: Option[ConditionExpression]
+    ) extends Write
+  }
+
   private[dynamodb] final case class BatchWriteItem(
     requestItems: MapOfSet[TableName, BatchWriteItem.Write] = MapOfSet.empty,
     capacity: ReturnConsumedCapacity = ReturnConsumedCapacity.None,

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -342,6 +342,12 @@ object DynamoDBQuery {
   import scala.collection.immutable.{ Map => ScalaMap }
   import scala.collection.immutable.{ Set => ScalaSet }
 
+  /*
+  sealed trait Constructor[+A]   extends DynamoDBQuery[A]
+  sealed trait Transaction[+A]   extends Constructor[A]
+  sealed trait Write[+A]         extends Constructor[A]
+   */
+
   sealed trait Constructor[+A]   extends DynamoDBQuery[A]
   sealed trait TransactWrite[+A] extends Constructor[A]
   sealed trait Write[+A]         extends TransactWrite[A]
@@ -830,6 +836,9 @@ object DynamoDBQuery {
     returnValues: ReturnValues = ReturnValues.None
   ) extends TransactWrite[Option[Item]]
 
+  // REVIEW: Does this make sense to extend?
+  // It's only ever used in transactions and doesn't return anything.
+  // AWS Impl just does a ZIO.unit
   private[dynamodb] final case class ConditionCheck(
     tableName: TableName,
     primaryKey: PrimaryKey,

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -348,6 +348,21 @@ object DynamoDBQuery {
   sealed trait Write[+A]         extends Constructor[A]
    */
 
+  /*
+
+  TRANSACTIONS
+  puts
+  deletes
+  updates
+  condition checks
+
+  NORMAL WRITES
+
+  deletes
+  puts
+
+   */
+
   sealed trait Constructor[+A]   extends DynamoDBQuery[A]
   sealed trait TransactWrite[+A] extends Constructor[A]
   sealed trait Write[+A]         extends TransactWrite[A]
@@ -835,6 +850,21 @@ object DynamoDBQuery {
     itemMetrics: ReturnItemCollectionMetrics = ReturnItemCollectionMetrics.None,
     returnValues: ReturnValues = ReturnValues.None
   ) extends TransactWrite[Option[Item]]
+
+  /*
+  in the impl we break everything in the query that is transactionable into a transaction
+  and if there is something that is not transactionable then we fail with a specific case class exception "nonTransactQuery" that shows what you're trying to do that is not transactionable
+    - tell the user what operator they're using that is not transactable
+
+  should be able to wrap transactions inside of each other and get a single transaction -- nestable
+
+   */
+
+  private[dynamodb] final case class Transaction[A](
+    query: DynamoDBQuery[A]
+  ) extends DynamoDBQuery[A]
+
+  def transaction[A](query: DynamoDBQuery[A]): DynamoDBQuery[A] = ???
 
   // REVIEW: Does this make sense to extend?
   // It's only ever used in transactions and doesn't return anything.

--- a/dynamodb/src/main/scala/zio/dynamodb/MapOfSet.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/MapOfSet.scala
@@ -45,6 +45,6 @@ private[dynamodb] final case class MapOfSet[K, V] private (private val map: Scal
   override def iterator: Iterator[(K, Set[V])] = map.iterator
 }
 private[dynamodb] object MapOfSet {
-  private def apply[K, V](map: ScalaMap[K, Set[V]]) = new MapOfSet(map)
-  def empty[K, V]: MapOfSet[K, V]                   = apply(ScalaMap.empty)
+  private[dynamodb] def apply[K, V](map: ScalaMap[K, Set[V]]) = new MapOfSet(map)
+  def empty[K, V]: MapOfSet[K, V]                             = apply(ScalaMap.empty)
 }

--- a/dynamodb/src/test/scala/zio/dynamodb/TransactionModelSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/TransactionModelSpec.scala
@@ -83,7 +83,7 @@ object TransactionModelSpec extends DefaultRunnableSpec {
     value(TransactWriteItemsResponse().asReadOnly)
   )
 
-  private val getLayer: ULayer[DynamoDb]         =
+  private val successCaseLayer: ULayer[DynamoDb] =
     multiTableBatchGet
       .or(batchGetTransaction)
       .or(getTransaction)
@@ -92,11 +92,10 @@ object TransactionModelSpec extends DefaultRunnableSpec {
       .or(putItem)
       .or(batchWriteItem)
   private val clockLayer                         = ZLayer.identity[Has[Clock.Service]]
-//  private val partialExecutor                    = (ZLayer.identity[Has[DynamoDb.Service]] ++ clockLayer) >>> DynamoDBExecutor.live
   override def spec: ZSpec[Environment, Failure] =
     suite("Transaction builder suite")(
       failureSuite.provideCustomLayer((emptyDynamoDB ++ clockLayer) >>> DynamoDBExecutor.live),
-      successfulSuite.provideCustomLayer((getLayer ++ clockLayer) >>> DynamoDBExecutor.live)
+      successfulSuite.provideCustomLayer((successCaseLayer ++ clockLayer) >>> DynamoDBExecutor.live)
     )
 
   val failureSuite = suite("transaction construction failures")(

--- a/dynamodb/src/test/scala/zio/dynamodb/TransactionModelSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/TransactionModelSpec.scala
@@ -1,0 +1,109 @@
+package zio.dynamodb
+
+import io.github.vigoo.zioaws.dynamodb.DynamoDb
+import io.github.vigoo.zioaws.dynamodb.DynamoDb.DynamoDbMock
+import zio.{ Chunk, Has, ULayer, ZLayer }
+import zio.clock.Clock
+import zio.dynamodb.DynamoDBQuery.{
+  CreateTable,
+  DeleteTable,
+  DescribeTable,
+  DescribeTableResponse,
+  GetItem,
+  ScanAll,
+  ScanSome,
+  TableStatus,
+  UpdateItem
+}
+import zio.dynamodb.ProjectionExpression.$
+import zio.test.Assertion.equalTo
+import zio.test.TestAspect.failing
+import zio.test.{ assertM, DefaultRunnableSpec, ZSpec }
+
+object TransactionModelSpec extends DefaultRunnableSpec {
+  private val tableName                          = TableName("table")
+  private val item                               = Item("a" -> 1)
+  private val emptyDynamoDB: ULayer[DynamoDb]    = DynamoDbMock.empty
+  private val clockLayer                         = ZLayer.identity[Has[Clock.Service]]
+  override def spec: ZSpec[Environment, Failure] =
+    suite("Transaction builder suite")(
+      failureSuite.provideCustomLayer((emptyDynamoDB ++ clockLayer) >>> DynamoDBExecutor.live)
+    )
+
+  val failureSuite = suite("transaction construction failures")(
+    suite("mixed transaction types")(
+      testM("mixing update and get") {
+        val updateItem = UpdateItem(
+          key = item,
+          tableName = tableName,
+          updateExpression = UpdateExpression($("name").set(""))
+        )
+
+        val getItem = GetItem(tableName, item)
+
+        assertM(updateItem.zip(getItem).transaction.execute)(equalTo((None, None)))
+      } @@ failing
+    ),
+    suite("invalid transaction actions")(
+      testM("create table") {
+        val createTable = CreateTable(
+          tableName = tableName,
+          keySchema = KeySchema("key"),
+          attributeDefinitions = NonEmptySet(AttributeDefinition.attrDefnString("name")),
+          billingMode = BillingMode.PayPerRequest
+        )
+
+        assertM(createTable.transaction.execute)(equalTo(()))
+      } @@ failing,
+      testM("delete table") {
+        val deleteTable = DeleteTable(tableName)
+
+        assertM(deleteTable.transaction.execute)(equalTo(()))
+      } @@ failing,
+      testM("scan all") {
+        val scanAll = ScanAll(tableName)
+        assertM(scanAll.transaction.execute)(equalTo(zio.stream.Stream.empty))
+      } @@ failing,
+      testM("scan some") {
+        val scanSome = ScanSome(tableName, 4)
+        assertM(scanSome.transaction.execute)(equalTo((Chunk.empty, None)))
+      } @@ failing,
+      testM("describe table") {
+        val describeTable = DescribeTable(tableName)
+        assertM(describeTable.transaction.execute)(equalTo(DescribeTableResponse("", TableStatus.Creating)))
+      } @@ failing
+//      testM("query some") {
+//        ???
+//      },
+//      testM("query all") {
+//        ???
+//      }
+    )
+  )
+
+//  val successfulSuite = suite("transaction construction successes")(
+//    suite("transact get items")(
+//      testM("batch get item") {
+//        ???
+//      },
+//      testM("get item") {
+//        ???
+//      }
+//    ),
+//    suite("transact write items")(
+//      testM("update item") {
+//        ???
+//      },
+//      testM("delete item") {
+//        ???
+//      },
+//      testM("put item") {
+//        ???
+//      },
+//      testM("batch write item") {
+//        ???
+//      }
+//    )
+//  )
+
+}

--- a/dynamodb/src/test/scala/zio/dynamodb/TransactionModelSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/TransactionModelSpec.scala
@@ -109,6 +109,10 @@ object TransactionModelSpec extends DefaultRunnableSpec {
 //      testM("get item") {
 //        assertM(simpleGetItem.transaction.execute)(equalTo(Some(item)))
 //      },
+      /* Need more tests around this, at least but not limited to:
+          - asking for values that don't exist
+          - multiple tables with varying request sizes
+       */
       testM("batch get item") {
         assertM(simpleBatchGet.transaction.execute)(
           equalTo(

--- a/dynamodb/src/test/scala/zio/dynamodb/TransactionModelSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/TransactionModelSpec.scala
@@ -21,7 +21,7 @@ object TransactionModelSpec extends DefaultRunnableSpec {
   private val simpleGetItem                   = GetItem(tableName, item)
   private val simpleGetItem2                  = GetItem(tableName, item2)
   private val simpleGetItem3                  = GetItem(tableName2, item3)
-  private val simpleUpdateItem                = UpdateItem(tableName, item, UpdateExpression($("a").set(4)))
+  private val simpleUpdateItem                = UpdateItem(tableName, item, UpdateExpression($("a").setValue(4)))
   private val simpleDeleteItem                = DeleteItem(tableName, item)
   private val simplePutItem                   = PutItem(tableName, item)
   private val simpleBatchWrite                = BatchWriteItem().addAll(simplePutItem, simpleDeleteItem)

--- a/dynamodb/src/test/scala/zio/dynamodb/TransactionModelSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/TransactionModelSpec.scala
@@ -29,7 +29,7 @@ object TransactionModelSpec extends DefaultRunnableSpec {
   private val multiTableGet                   = BatchGetItem().addAll(simpleGetItem, simpleGetItem2, simpleGetItem3)
   private val emptyDynamoDB: ULayer[DynamoDb] = DynamoDbMock.empty
   val getTransaction                          = DynamoDbMock.TransactGetItems(
-    equalTo(DynamoDBExecutorImpl.constructGetTransaction(Chunk(simpleGetItem))),
+    equalTo(DynamoDBExecutorImpl.constructGetTransaction(Chunk(simpleGetItem), ReturnConsumedCapacity.None)),
     value(
       TransactGetItemsResponse(
         consumedCapacity = None,
@@ -38,7 +38,7 @@ object TransactionModelSpec extends DefaultRunnableSpec {
     )
   )
   val batchGetTransaction                     = DynamoDbMock.TransactGetItems(
-    equalTo(DynamoDBExecutorImpl.constructGetTransaction(Chunk(simpleBatchGet))),
+    equalTo(DynamoDBExecutorImpl.constructGetTransaction(Chunk(simpleBatchGet), ReturnConsumedCapacity.None)),
     value(
       TransactGetItemsResponse(
         consumedCapacity = None,
@@ -52,7 +52,7 @@ object TransactionModelSpec extends DefaultRunnableSpec {
     )
   )
   val multiTableBatchGet                      = DynamoDbMock.TransactGetItems(
-    equalTo(DynamoDBExecutorImpl.constructGetTransaction(Chunk(multiTableGet))),
+    equalTo(DynamoDBExecutorImpl.constructGetTransaction(Chunk(multiTableGet), ReturnConsumedCapacity.None)),
     value(
       TransactGetItemsResponse(
         consumedCapacity = None,
@@ -67,19 +67,47 @@ object TransactionModelSpec extends DefaultRunnableSpec {
     )
   )
   val updateItem                              = DynamoDbMock.TransactWriteItems(
-    equalTo(DynamoDBExecutorImpl.constructWriteTransaction(Chunk(simpleUpdateItem))),
+    equalTo(
+      DynamoDBExecutorImpl.constructWriteTransaction(
+        Chunk(simpleUpdateItem),
+        None,
+        ReturnConsumedCapacity.None,
+        ReturnItemCollectionMetrics.None
+      )
+    ),
     value(TransactWriteItemsResponse().asReadOnly)
   )
   val deleteItem                              = DynamoDbMock.TransactWriteItems(
-    equalTo(DynamoDBExecutorImpl.constructWriteTransaction(Chunk(simpleDeleteItem))),
+    equalTo(
+      DynamoDBExecutorImpl.constructWriteTransaction(
+        Chunk(simpleDeleteItem),
+        None,
+        ReturnConsumedCapacity.None,
+        ReturnItemCollectionMetrics.None
+      )
+    ),
     value(TransactWriteItemsResponse().asReadOnly)
   )
   val putItem                                 = DynamoDbMock.TransactWriteItems(
-    equalTo(DynamoDBExecutorImpl.constructWriteTransaction(Chunk(simplePutItem))),
+    equalTo(
+      DynamoDBExecutorImpl.constructWriteTransaction(
+        Chunk(simplePutItem),
+        None,
+        ReturnConsumedCapacity.None,
+        ReturnItemCollectionMetrics.None
+      )
+    ),
     value(TransactWriteItemsResponse().asReadOnly)
   )
   val batchWriteItem                          = DynamoDbMock.TransactWriteItems(
-    equalTo(DynamoDBExecutorImpl.constructWriteTransaction(Chunk(simpleBatchWrite))),
+    equalTo(
+      DynamoDBExecutorImpl.constructWriteTransaction(
+        Chunk(simpleBatchWrite),
+        None,
+        ReturnConsumedCapacity.None,
+        ReturnItemCollectionMetrics.None
+      )
+    ),
     value(TransactWriteItemsResponse().asReadOnly)
   )
 


### PR DESCRIPTION
Adding transaction functionality. A user can now build a DynamoDBQuery and call `.transaction` on it to have it be executed as a single transaction. Currently if there are problems with the transaction, like mixing Get and Write actions, the user will get a failing ZIO effect. There is also a `safeTransaction` method that returns an `Either[Throwable, DynamoDBQuery[A]]` for type safe transactions. I'm happy to change that method name if someone has a different suggestion.