### PR TITLE
fixed missing optional field bug

### DIFF
--- a/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
@@ -799,18 +799,14 @@ private[dynamodb] object Codec {
       @tailrec
       def unwrapLazySchema[B](schema: Schema[B]): Schema[B] =
         schema match {
-          case l @ Schema.Lazy(_) =>
-            unwrapLazySchema(l.schema)
-          case s                  =>
-            s
+          case l @ Schema.Lazy(_) => unwrapLazySchema(l.schema)
+          case s                  => s
         }
 
       def isOptional[B](schema: Schema[B]): Boolean =
         schema match {
-          case _: Schema.Optional[a] =>
-            true
-          case _                     =>
-            false
+          case _: Schema.Optional[a] => true
+          case _                     => false
         }
 
       av match {

--- a/dynamodb/src/test/scala/zio/dynamodb/GetAndPutSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/GetAndPutSpec.scala
@@ -8,7 +8,10 @@ import zio.test.{ assertTrue, DefaultRunnableSpec, ZSpec }
 
 object GetAndPutSpec extends DefaultRunnableSpec {
   final case class SimpleCaseClass2(id: Int, name: String)
-  implicit lazy val simpleCaseClass2: Schema[SimpleCaseClass2] = DeriveSchema.gen[SimpleCaseClass2]
+  final case class SimpleCaseClass2OptionalField(id: Int, maybeName: Option[String])
+  implicit lazy val simpleCaseClass2: Schema[SimpleCaseClass2]                           = DeriveSchema.gen[SimpleCaseClass2]
+  implicit lazy val simpleCaseClass2OptionalField: Schema[SimpleCaseClass2OptionalField] =
+    DeriveSchema.gen[SimpleCaseClass2OptionalField]
 
   private val primaryKey1 = PrimaryKey("id" -> 1)
   private val primaryKey2 = PrimaryKey("id" -> 2)

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/CodecTestFixtures.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/CodecTestFixtures.scala
@@ -32,6 +32,7 @@ trait CodecTestFixtures {
   lazy implicit val caseClassOfListOfCaseClass: Schema[CaseClassOfListOfCaseClass] =
     DeriveSchema.gen[CaseClassOfListOfCaseClass]
   lazy implicit val caseClassOfOption: Schema[CaseClassOfOption]                   = DeriveSchema.gen[CaseClassOfOption]
+  lazy implicit val caseClass2OfOption: Schema[CaseClass2OfOption]                 = DeriveSchema.gen[CaseClass2OfOption]
   lazy implicit val caseClassOfNestedOption: Schema[CaseClassOfNestedOption]       = DeriveSchema.gen[CaseClassOfNestedOption]
   lazy implicit val caseClassOfEither: Schema[CaseClassOfEither]                   = DeriveSchema.gen[CaseClassOfEither]
   lazy implicit val caseClassOfTuple2: Schema[CaseClassOfTuple2]                   = DeriveSchema.gen[CaseClassOfTuple2]

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/ItemDecoderSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/ItemDecoderSpec.scala
@@ -49,6 +49,13 @@ object ItemDecoderSpec extends DefaultRunnableSpec with CodecTestFixtures {
 
       assert(actual)(isRight(equalTo(expected)))
     },
+    test("decoded option of None in CaseClass2") {
+      val expected = CaseClass2OfOption(1, None)
+
+      val actual = DynamoDBQuery.fromItem[CaseClass2OfOption](Item("num" -> 1))
+
+      assert(actual)(isRight(equalTo(expected)))
+    },
     test("decoded nested option of Some") {
       val expected = CaseClassOfNestedOption(Some(Some(42)))
 

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/ItemDecoderSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/ItemDecoderSpec.scala
@@ -49,7 +49,7 @@ object ItemDecoderSpec extends DefaultRunnableSpec with CodecTestFixtures {
 
       assert(actual)(isRight(equalTo(expected)))
     },
-    test("decoded option of None in CaseClass2") {
+    test("decoded option of None in CaseClass2 represented by a missing value") {
       val expected = CaseClass2OfOption(1, None)
 
       val actual = DynamoDBQuery.fromItem[CaseClass2OfOption](Item("num" -> 1))

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/models.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/models.scala
@@ -22,6 +22,7 @@ final case class CaseClassOfList(nums: List[Int])
 final case class CaseClassOfListOfCaseClass(elements: List[SimpleCaseClass3])
 
 final case class CaseClassOfOption(opt: Option[Int])
+final case class CaseClass2OfOption(num: Int, opt: Option[Int])
 
 final case class CaseClassOfNestedOption(opt: Option[Option[Int]])
 


### PR DESCRIPTION
Some legacy databases will be using the absence of a value to encode a `None` for an `Option[A]` - and we were not handling this case - this PR fixes this.