### PR TITLE
fix for option encoding, added type safe set, allowed numerics in PE $

### DIFF
--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -420,7 +420,7 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("update name") {
             withDefaultTable { tableName =>
               for {
-                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).set(notAdam)).execute
+                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).setValue(notAdam)).execute
                 updated         <- getItem(
                                      tableName,
                                      secondPrimaryKey
@@ -433,7 +433,7 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("update name return updated old") {
             withDefaultTable { tableName =>
               for {
-                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).set(notAdam))
+                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).setValue(notAdam))
                                      .returns(ReturnValues.UpdatedOld)
                                      .execute
                 updated         <- getItem(
@@ -447,7 +447,7 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("update name return all old") {
             withDefaultTable { tableName =>
               for {
-                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).set(notAdam))
+                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).setValue(notAdam))
                                      .returns(ReturnValues.AllOld)
                                      .execute
                 updated         <- getItem(
@@ -462,7 +462,7 @@ object LiveSpec extends DefaultRunnableSpec {
             withDefaultTable { tableName =>
               val updatedItem = Some(Item(name -> notAdam, id -> second, number -> 2))
               for {
-                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).set(notAdam))
+                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).setValue(notAdam))
                                      .returns(ReturnValues.AllNew)
                                      .execute
                 updated         <- getItem(
@@ -476,7 +476,7 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("update name return updated new") {
             withDefaultTable { tableName =>
               for {
-                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).set(notAdam))
+                updatedResponse <- updateItem(tableName, secondPrimaryKey)($(name).setValue(notAdam))
                                      .returns(ReturnValues.UpdatedNew)
                                      .execute
                 updated         <- getItem(
@@ -490,8 +490,8 @@ object LiveSpec extends DefaultRunnableSpec {
           testM("insert item into list") {
             withDefaultTable { tableName =>
               for {
-                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").set(List(1))).execute
-                _       <- updateItem(tableName, secondPrimaryKey)($("listThing[1]").set(2)).execute
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing").setValue(List(1))).execute
+                _       <- updateItem(tableName, secondPrimaryKey)($("listThing[1]").setValue(2)).execute
                 updated <- getItem(
                              tableName,
                              secondPrimaryKey
@@ -505,7 +505,7 @@ object LiveSpec extends DefaultRunnableSpec {
             withDefaultTable {
               tableName =>
                 for {
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").set(List(1))).execute
+                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").setValue(List(1))).execute
                   _       <- updateItem(tableName, secondPrimaryKey)($("listThing").appendList(Chunk(2, 3, 4))).execute
                   updated <- getItem(tableName, secondPrimaryKey).execute
                 } yield assert(
@@ -521,7 +521,7 @@ object LiveSpec extends DefaultRunnableSpec {
             withDefaultTable {
               tableName =>
                 for {
-                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").set(List(1))).execute
+                  _       <- updateItem(tableName, secondPrimaryKey)($("listThing").setValue(List(1))).execute
                   _       <- updateItem(tableName, secondPrimaryKey)($("listThing").prependList(Chunk(-1, 0))).execute
                   updated <- getItem(tableName, secondPrimaryKey).execute
                 } yield assert(

--- a/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
@@ -178,9 +178,11 @@ private[dynamodb] object Codec {
             @tailrec
             def appendToMap[B](schema: Schema[B]): AttributeValue.Map =
               schema match {
-                case l @ Schema.Lazy(_) =>
+                case l @ Schema.Lazy(_)                                                 =>
                   appendToMap(l.schema)
-                case _                  =>
+                case _: Schema.Optional[_] if av.isInstanceOf[AttributeValue.Null.type] =>
+                  AttributeValue.Map(acc.value)
+                case _                                                                  =>
                   AttributeValue.Map(acc.value + (AttributeValue.String(k) -> av))
               }
 

--- a/dynamodb/src/main/scala/zio/dynamodb/ProjectionExpression.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/ProjectionExpression.scala
@@ -2,8 +2,10 @@ package zio.dynamodb
 
 import zio.Chunk
 import zio.dynamodb.ConditionExpression.Operand.ProjectionExpressionOperand
+import zio.dynamodb.DynamoDBQuery.toItem
 import zio.dynamodb.ProjectionExpression.{ ListElement, MapElement, Root }
 import zio.dynamodb.UpdateExpression.SetOperand.{ IfNotExists, ListAppend, ListPrepend, PathOperand }
+import zio.schema.Schema
 
 import scala.annotation.tailrec
 
@@ -119,8 +121,10 @@ sealed trait ProjectionExpression { self =>
   /**
    * Modify or Add an item Attribute
    */
-  def set[A](a: A)(implicit t: ToAttributeValue[A]): UpdateExpression.Action.SetAction =
+  def setValue[A](a: A)(implicit t: ToAttributeValue[A]): UpdateExpression.Action.SetAction =
     UpdateExpression.Action.SetAction(self, UpdateExpression.SetOperand.ValueOperand(t.toAttributeValue(a)))
+
+  def set[A: Schema](a: A): UpdateExpression.Action.SetAction = setValue(toItem(a))
 
   /**
    * Modify or Add an item Attribute

--- a/dynamodb/src/main/scala/zio/dynamodb/ProjectionExpression.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/ProjectionExpression.scala
@@ -184,8 +184,8 @@ sealed trait ProjectionExpression { self =>
 }
 
 object ProjectionExpression {
-  private val regexMapElement     = """(^[a-zA-Z_]+)""".r
-  private val regexIndexedElement = """(^[a-zA-Z_]+)(\[[0-9]+])+""".r
+  private val regexMapElement     = """(^[a-zA-Z0-9_]+)""".r
+  private val regexIndexedElement = """(^[a-zA-Z0-9_]+)(\[[0-9]+])+""".r
   private val regexGroupedIndexes = """(\[([0-9]+)])""".r
 
   // Note that you can only use a ProjectionExpression if the first character is a-z or A-Z and the second character

--- a/dynamodb/src/test/scala/zio/dynamodb/ProjectionExpressionParserSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/ProjectionExpressionParserSpec.scala
@@ -10,7 +10,7 @@ import scala.annotation.tailrec
 object ProjectionExpressionParserSpec extends DefaultRunnableSpec {
   object Generators {
     private val maxFields                                                                                    = 20
-    private val validCharGens                                                                                = List(Gen.const('_'), Gen.char('a', 'z'), Gen.char('a', 'z'))
+    private val validCharGens                                                                                = List(Gen.const('_'), Gen.char('a', 'z'), Gen.char('A', 'Z'), Gen.char('0', '9'))
     private def fieldName                                                                                    = Gen.stringBounded(0, 10)(Gen.oneOf(validCharGens: _*))
     private def index                                                                                        = Gen.int(0, 10)
     private def root: Gen[Random with Sized, Root]                                                           = fieldName.map(Root)
@@ -49,6 +49,9 @@ object ProjectionExpressionParserSpec extends DefaultRunnableSpec {
             else isRight(equalTo(pe))
           )
         }
+      },
+      test("toString on a ProjectionExpression of a_0[0]") {
+        assert(parse("a_0[0]"))(isRight)
       },
       test("toString on a ProjectionExpression of foo.bar[9].baz") {
         val pe = MapElement(ListElement(MapElement(Root("foo"), "bar"), 9), "baz")

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/ItemEncoderSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/ItemEncoderSpec.scala
@@ -37,7 +37,7 @@ object ItemEncoderSpec extends DefaultRunnableSpec with CodecTestFixtures {
       assert(item)(equalTo(expectedItem))
     },
     test("encodes simple Optional Item") {
-      val expectedItem: Item = Item("id" -> 2, "name" -> "Avi", "opt" -> null)
+      val expectedItem: Item = Item("id" -> 2, "name" -> "Avi")
 
       val item = DynamoDBQuery.toItem(SimpleCaseClass3Option(2, "Avi", opt = None))
 

--- a/examples/src/main/scala/zio/dynamodb/examples/UpdateExpressionExamples.scala
+++ b/examples/src/main/scala/zio/dynamodb/examples/UpdateExpressionExamples.scala
@@ -5,7 +5,7 @@ import zio.dynamodb.UpdateExpression.Action.{ AddAction, DeleteAction, RemoveAct
 import zio.dynamodb._
 
 object UpdateExpressionExamples extends App {
-  val set1: SetAction      = $("one[2]").set(1)
+  val set1: SetAction      = $("one[2]").setValue(1)
   val set2: SetAction      = $("one[2]").set($("two"))
   val set3: SetAction      = $("one[2]").setIfNotExists($("two"), "v2")
   val set4: SetAction      = $("one[2]").appendList(List("1"))
@@ -13,11 +13,11 @@ object UpdateExpressionExamples extends App {
   val add: AddAction       = $("one[2]").add("V2")
   val remove: RemoveAction = $("one[2]").remove
   val delete: DeleteAction = $("one[2]").deleteFromSet("v2")
-  val pe8: SetAction       = $("one[2]").set(Item("x" -> "x"))
+  val pe8: SetAction       = $("one[2]").setValue(Item("x" -> "x"))
 
   val ops: UpdateExpression =
     UpdateExpression(
-      $("one[2]").set(1) +
+      $("one[2]").setValue(1) +
         $("one[2]").set($("two")) +
         $("one[2]").setIfNotExists($("two"), "v2") +
         $("one[2]").appendList(List("x1", "x2")) +
@@ -27,14 +27,14 @@ object UpdateExpressionExamples extends App {
         $("one[2]").deleteFromSet(1)
     )
 
-  $("one[2]").set("v2")
-  $("one[2]").set(Set("s"))
-  $("one[2]").set(List("42".toByte))
-  $("one[2]").set(List(List("41".toByte)))
-  $("one[2]").set(1)
-  $("one[2]").set(Set(1))
-  $("one[2]").set(List("x"))
+  $("one[2]").setValue("v2")
+  $("one[2]").setValue(Set("s"))
+  $("one[2]").setValue(List("42".toByte))
+  $("one[2]").setValue(List(List("41".toByte)))
+  $("one[2]").setValue(1)
+  $("one[2]").setValue(Set(1))
+  $("one[2]").setValue(List("x"))
 
-  DynamoDBQuery.updateItem("tableName1", PrimaryKey("id" -> 1))($("foo.bar").set(2))
+  DynamoDBQuery.updateItem("tableName1", PrimaryKey("id" -> 1))($("foo.bar").setValue(2))
 
 }

--- a/examples/src/main/scala/zio/dynamodb/examples/UpdateItemExamples.scala
+++ b/examples/src/main/scala/zio/dynamodb/examples/UpdateItemExamples.scala
@@ -8,7 +8,7 @@ import zio.dynamodb.ProjectionExpression.$
 object UpdateItemExamples {
 
   val pi1 = updateItem("tableName1", PrimaryKey("field1" -> 1)) {
-    $("foo.bar").set("a_value") +
+    $("foo.bar").setValue("a_value") +
       $("bar.foo").remove +
       $("foo.foo").appendList(Chunk("s")) +
       $("foo.foo").prependList(Chunk("s")) +


### PR DESCRIPTION
- option encoding was using NULL type to represent None, however this causes problems with secondary index fields which complain about NULLs not having the same type as the field. This has been fixed by omitting fields if they are None
- renamed existing update action `set` to `setValue` and added a new type safe version called `set` - this is useful when we wish to update parts of DB record using a case class.
- relaxed projection expression $ parse method to allow numbers