### PR TITLE
PutItem & DeleteItem where clause respected

### DIFF
--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -214,6 +214,18 @@ object LiveSpec extends DefaultRunnableSpec {
             getItem(tableName, PrimaryKey(id -> "nowhere", number -> 1000)).execute.map(item => assert(item)(isNone))
           }
         },
+        testM("delete item with where clause") {
+          withDefaultTable { tableName =>
+            val deleteItem = DeleteItem(
+              key = pk(avi3Item),
+              tableName = TableName(tableName)
+            ).where($("firstName").beginsWith("avi"))
+            for {
+              _                <- deleteItem.execute
+              maybeDeletedItem <- getItem(tableName, pk(avi3Item)).execute
+            } yield assert(maybeDeletedItem)(isNone)
+          }
+        },
         testM("batch get item") {
           withDefaultTable { tableName =>
             val getItems = BatchGetItem().addAll(
@@ -744,18 +756,6 @@ object LiveSpec extends DefaultRunnableSpec {
                 key = pk(avi3Item),
                 tableName = TableName(tableName)
               )
-              for {
-                _       <- deleteItem.transaction.execute
-                written <- getItem(tableName, PrimaryKey(id -> first, number -> 7)).execute
-              } yield assert(written)(isNone)
-            }
-          },
-          testM("delete item with where clause") {
-            withDefaultTable { tableName =>
-              val deleteItem = DeleteItem(
-                key = pk(avi3Item),
-                tableName = TableName(tableName)
-              ).where($("firstName").beginsWith("avi"))
               for {
                 _       <- deleteItem.transaction.execute
                 written <- getItem(tableName, PrimaryKey(id -> first, number -> 7)).execute

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -750,6 +750,18 @@ object LiveSpec extends DefaultRunnableSpec {
               } yield assert(written)(isNone)
             }
           },
+          testM("delete item with where clause") {
+            withDefaultTable { tableName =>
+              val deleteItem = DeleteItem(
+                key = pk(avi3Item),
+                tableName = TableName(tableName)
+              ).where($("firstName").beginsWith("avi"))
+              for {
+                _       <- deleteItem.transaction.execute
+                written <- getItem(tableName, PrimaryKey(id -> first, number -> 7)).execute
+              } yield assert(written)(isNone)
+            }
+          },
           testM("update item") {
             withDefaultTable { tableName =>
               val updateItem = UpdateItem(

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -219,11 +219,11 @@ object LiveSpec extends DefaultRunnableSpec {
             val deleteItem = DeleteItem(
               key = pk(avi3Item),
               tableName = TableName(tableName)
-            ).where($("firstName").beginsWith("avi"))
+            ).where($("firstName").beginsWith("noOne"))
             for {
               _                <- deleteItem.execute
               maybeDeletedItem <- getItem(tableName, pk(avi3Item)).execute
-            } yield assert(maybeDeletedItem)(isNone)
+            } yield assert(maybeDeletedItem)(isSome)
           }
         },
         testM("batch get item") {

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -214,16 +214,23 @@ object LiveSpec extends DefaultRunnableSpec {
             getItem(tableName, PrimaryKey(id -> "nowhere", number -> 1000)).execute.map(item => assert(item)(isNone))
           }
         },
-        testM("delete item with where clause") {
+        testM("delete item with false where clause") {
           withDefaultTable { tableName =>
             val deleteItem = DeleteItem(
               key = pk(avi3Item),
               tableName = TableName(tableName)
             ).where($("firstName").beginsWith("noOne"))
-            for {
-              _                <- deleteItem.execute
-              maybeDeletedItem <- getItem(tableName, pk(avi3Item)).execute
-            } yield assert(maybeDeletedItem)(isSome)
+            assertM(deleteItem.execute.run)(fails(assertDynamoDbException("The conditional request failed")))
+          }
+        },
+        testM("put item with false where clause") {
+          withDefaultTable { tableName =>
+            val putItem = PutItem(
+              tableName = TableName(tableName),
+              item = Item(id -> "nothing", number -> 900)
+            ).where($("id").beginsWith("false"))
+
+            assertM(putItem.execute.run)(fails(assertDynamoDbException("The conditional request failed")))
           }
         },
         testM("batch get item") {
@@ -747,7 +754,13 @@ object LiveSpec extends DefaultRunnableSpec {
 
               assertM(
                 conditionCheck.zip(putItem).transaction.execute.run
-              )(fails(assertDynamoDbException("ConditionalCheckFailed")))
+              )(
+                fails(
+                  assertDynamoDbException(
+                    "Transaction cancelled, please refer cancellation reasons for specific reasons [ConditionalCheckFailed, None]"
+                  )
+                )
+              )
             }
           },
           testM("delete item") {

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -865,13 +865,19 @@ object DynamoDBQuery {
       constructors.zipWithIndex.foldLeft[(Chunk[IndexedConstructor], Chunk[IndexedGetItem], Chunk[IndexedWriteItem])](
         (Chunk.empty, Chunk.empty, Chunk.empty)
       ) {
-        case ((nonBatched, gets, writes), (get @ GetItem(_, _, _, _, _), index))          =>
+        case ((nonBatched, gets, writes), (get @ GetItem(_, _, _, _, _), index))                            =>
           (nonBatched, gets :+ (get -> index), writes)
-        case ((nonBatched, gets, writes), (put @ PutItem(_, _, _, _, _, _), index))       =>
-          (nonBatched, gets, writes :+ (put -> index))
-        case ((nonBatched, gets, writes), (delete @ DeleteItem(_, _, _, _, _, _), index)) =>
-          (nonBatched, gets, writes :+ (delete -> index))
-        case ((nonBatched, gets, writes), (nonGetItem, index))                            =>
+        case ((nonBatched, gets, writes), (put @ PutItem(_, _, conditionExpression, _, _, _), index))       =>
+          conditionExpression match {
+            case Some(_) => (nonBatched :+ (put -> index), gets, writes)
+            case None    => (nonBatched, gets, writes :+ (put -> index))
+          }
+        case ((nonBatched, gets, writes), (delete @ DeleteItem(_, _, conditionExpression, _, _, _), index)) =>
+          conditionExpression match {
+            case Some(_) => (nonBatched :+ (delete -> index), gets, writes)
+            case None    => (nonBatched, gets, writes :+ (delete -> index))
+          }
+        case ((nonBatched, gets, writes), (nonGetItem, index))                                              =>
           (nonBatched :+ (nonGetItem -> index), gets, writes)
       }
 


### PR DESCRIPTION
Looks like there were a couple bugs related to this. The first was batching doesn't respect `ConditionExpression`s so they were ignored completely. The second was that `ConditionExpression`s for `DeleteItem` and `PutItem` were being rendered incorrectly. This fixes both bugs and adds a couple of tests to cover these cases.

I also updated the string match for one of the failing transactions to be more specific.

Should close #112 