### PR TITLE
ZIO2 skip-empty-sets and fix-delete-where

### DIFF
--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -228,6 +228,25 @@ object LiveSpec extends ZIOSpecDefault {
             } yield assert(a.flatMap(_.map.get("emptySet")))(isNone)
           }
         },
+        test("delete item with false where clause") {
+          withDefaultTable { tableName =>
+            val deleteItem = DeleteItem(
+              key = pk(avi3Item),
+              tableName = TableName(tableName)
+            ).where($("firstName").beginsWith("noOne"))
+            assertM(deleteItem.execute.exit)(fails(assertDynamoDbException("The conditional request failed")))
+          }
+        },
+        test("put item with false where clause") {
+          withDefaultTable { tableName =>
+            val putItem = PutItem(
+              tableName = TableName(tableName),
+              item = Item(id -> "nothing", number -> 900)
+            ).where($("id").beginsWith("false"))
+
+            assertM(putItem.execute.exit)(fails(assertDynamoDbException("The conditional request failed")))
+          }
+        },
         test("batch get item") {
           withDefaultTable { tableName =>
             val getItems = BatchGetItem().addAll(
@@ -553,33 +572,35 @@ object LiveSpec extends ZIOSpecDefault {
             }
           },
           test("append to list") {
-            withDefaultTable { tableName =>
-              for {
-                _       <- updateItem(tableName, pk(adamItem))($("listThing").setValue(List(1))).execute
-                _       <- updateItem(tableName, pk(adamItem))($("listThing").appendList(Chunk(2, 3, 4))).execute
-                updated <- getItem(tableName, pk(adamItem)).execute
-              } yield assert(
-                updated.map(a =>
-                  a.get("listThing")(
-                    FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
+            withDefaultTable {
+              tableName =>
+                for {
+                  _       <- updateItem(tableName, pk(adamItem))($("listThing").setValue(List(1))).execute
+                  _       <- updateItem(tableName, pk(adamItem))($("listThing").appendList(Chunk(2, 3, 4))).execute
+                  updated <- getItem(tableName, pk(adamItem)).execute
+                } yield assert(
+                  updated.map(a =>
+                    a.get("listThing")(
+                      FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
+                    )
                   )
-                )
-              )(equalTo(Some(Right(List(1, 2, 3, 4)))))
+                )(equalTo(Some(Right(List(1, 2, 3, 4)))))
             }
           },
           test("prepend to list") {
-            withDefaultTable { tableName =>
-              for {
-                _       <- updateItem(tableName, pk(adamItem))($("listThing").setValue(List(1))).execute
-                _       <- updateItem(tableName, pk(adamItem))($("listThing").prependList(Chunk(-1, 0))).execute
-                updated <- getItem(tableName, pk(adamItem)).execute
-              } yield assert(
-                updated.map(a =>
-                  a.get("listThing")(
-                    FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
+            withDefaultTable {
+              tableName =>
+                for {
+                  _       <- updateItem(tableName, pk(adamItem))($("listThing").setValue(List(1))).execute
+                  _       <- updateItem(tableName, pk(adamItem))($("listThing").prependList(Chunk(-1, 0))).execute
+                  updated <- getItem(tableName, pk(adamItem)).execute
+                } yield assert(
+                  updated.map(a =>
+                    a.get("listThing")(
+                      FromAttributeValue.iterableFromAttributeValue(FromAttributeValue.intFromAttributeValue)
+                    )
                   )
-                )
-              )(equalTo(Some(Right(List(-1, 0, 1)))))
+                )(equalTo(Some(Right(List(-1, 0, 1)))))
             }
           },
           test("set an Item Attribute") {
@@ -727,41 +748,49 @@ object LiveSpec extends ZIOSpecDefault {
             }
           },
           test("condition check succeeds") {
-            withDefaultTable { tableName =>
-              val conditionCheck = ConditionCheck(
-                primaryKey = pk(avi3Item),
-                tableName = TableName(tableName),
-                conditionExpression = conditionAlwaysTrue
-              )
-              val putItem        = PutItem(
-                item = Item(id -> first, name -> avi3, number -> 10),
-                tableName = TableName(tableName)
-              )
+            withDefaultTable {
+              tableName =>
+                val conditionCheck = ConditionCheck(
+                  primaryKey = pk(avi3Item),
+                  tableName = TableName(tableName),
+                  conditionExpression = conditionAlwaysTrue
+                )
+                val putItem        = PutItem(
+                  item = Item(id -> first, name -> avi3, number -> 10),
+                  tableName = TableName(tableName)
+                )
 
-              for {
-                _       <- conditionCheck.zip(putItem).transaction.execute
-                written <- getItem(tableName, PrimaryKey(id -> first, number -> 10)).execute
-              } yield assert(written)(isSome)
+                for {
+                  _       <- conditionCheck.zip(putItem).transaction.execute
+                  written <- getItem(tableName, PrimaryKey(id -> first, number -> 10)).execute
+                } yield assert(written)(isSome)
             }
           },
           test("condition check fails because 'id' != 'first'") {
-            withDefaultTable { tableName =>
-              val conditionCheck = ConditionCheck(
-                primaryKey = pk(avi3Item),
-                tableName = TableName(tableName),
-                conditionExpression = ConditionExpression.Equals(
-                  ConditionExpression.Operand.ValueOperand(AttributeValue(id)),
-                  ConditionExpression.Operand.ValueOperand(AttributeValue(first))
+            withDefaultTable {
+              tableName =>
+                val conditionCheck = ConditionCheck(
+                  primaryKey = pk(avi3Item),
+                  tableName = TableName(tableName),
+                  conditionExpression = ConditionExpression.Equals(
+                    ConditionExpression.Operand.ValueOperand(AttributeValue(id)),
+                    ConditionExpression.Operand.ValueOperand(AttributeValue(first))
+                  )
                 )
-              )
-              val putItem        = PutItem(
-                item = Item(id -> first, name -> avi3, number -> 10),
-                tableName = TableName(tableName)
-              )
+                val putItem        = PutItem(
+                  item = Item(id -> first, name -> avi3, number -> 10),
+                  tableName = TableName(tableName)
+                )
 
-              assertM(
-                conditionCheck.zip(putItem).transaction.execute.exit
-              )(fails(assertDynamoDbException("ConditionalCheckFailed")))
+                assertM(
+                  conditionCheck.zip(putItem).transaction.execute.exit
+                )(
+                  fails(
+                    assertDynamoDbException(
+                      "Transaction cancelled, please refer cancellation reasons for specific reasons [ConditionalCheckFailed, None]"
+                    )
+                  )
+                )
             }
           },
           test("delete item") {
@@ -790,77 +819,80 @@ object LiveSpec extends ZIOSpecDefault {
             }
           },
           test("all transaction types at once") {
-            withDefaultTable { tableName =>
-              val putItem        = PutItem(
-                item = Item(id -> first, name -> avi3, number -> 10),
-                tableName = TableName(tableName)
-              )
-              val conditionCheck = ConditionCheck(
-                primaryKey = pk(aviItem),
-                tableName = TableName(tableName),
-                conditionExpression = conditionAlwaysTrue
-              )
-              val updateItem     = UpdateItem(
-                key = pk(avi3Item),
-                tableName = TableName(tableName),
-                updateExpression = UpdateExpression($(name).setValue(notAdam))
-              )
-              val deleteItem     = DeleteItem(
-                key = pk(avi2Item),
-                tableName = TableName(tableName)
-              )
+            withDefaultTable {
+              tableName =>
+                val putItem        = PutItem(
+                  item = Item(id -> first, name -> avi3, number -> 10),
+                  tableName = TableName(tableName)
+                )
+                val conditionCheck = ConditionCheck(
+                  primaryKey = pk(aviItem),
+                  tableName = TableName(tableName),
+                  conditionExpression = conditionAlwaysTrue
+                )
+                val updateItem     = UpdateItem(
+                  key = pk(avi3Item),
+                  tableName = TableName(tableName),
+                  updateExpression = UpdateExpression($(name).setValue(notAdam))
+                )
+                val deleteItem     = DeleteItem(
+                  key = pk(avi2Item),
+                  tableName = TableName(tableName)
+                )
 
-              for {
-                _       <- (putItem zip conditionCheck zip updateItem zip deleteItem).transaction.execute
-                put     <- get[Person](tableName, Item(id -> first, number -> 10)).execute
-                deleted <- get[Person](tableName, Item(id -> first, number -> 4)).execute
-                updated <- get[Person](tableName, Item(id -> first, number -> 7)).execute
-              } yield assert(put)(isRight(equalTo(Person(first, avi3, 10)))) &&
-                assert(deleted)(isLeft) &&
-                assert(updated)(isRight(equalTo(Person(first, notAdam, 7))))
+                for {
+                  _       <- (putItem zip conditionCheck zip updateItem zip deleteItem).transaction.execute
+                  put     <- get[Person](tableName, Item(id -> first, number -> 10)).execute
+                  deleted <- get[Person](tableName, Item(id -> first, number -> 4)).execute
+                  updated <- get[Person](tableName, Item(id -> first, number -> 7)).execute
+                } yield assert(put)(isRight(equalTo(Person(first, avi3, 10)))) &&
+                  assert(deleted)(isLeft) &&
+                  assert(updated)(isRight(equalTo(Person(first, notAdam, 7))))
             }
           },
           test("two updates to same item fails") {
-            withDefaultTable { tableName =>
-              val updateItem1 = UpdateItem(
-                key = pk(avi3Item),
-                tableName = TableName(tableName),
-                updateExpression = UpdateExpression($(name).setValue("abc"))
-              )
+            withDefaultTable {
+              tableName =>
+                val updateItem1 = UpdateItem(
+                  key = pk(avi3Item),
+                  tableName = TableName(tableName),
+                  updateExpression = UpdateExpression($(name).setValue("abc"))
+                )
 
-              val updateItem2 = UpdateItem(
-                key = pk(avi3Item),
-                tableName = TableName(tableName),
-                updateExpression = UpdateExpression($(name).setValue("shouldFail"))
-              )
+                val updateItem2 = UpdateItem(
+                  key = pk(avi3Item),
+                  tableName = TableName(tableName),
+                  updateExpression = UpdateExpression($(name).setValue("shouldFail"))
+                )
 
-              assertM(updateItem1.zip(updateItem2).transaction.execute.exit)(
-                fails(assertDynamoDbException("Transaction request cannot include multiple operations on one item"))
-              )
+                assertM(updateItem1.zip(updateItem2).transaction.execute.exit)(
+                  fails(assertDynamoDbException("Transaction request cannot include multiple operations on one item"))
+                )
             }
           },
           test("repeated client request token with different transaction fails") {
-            withDefaultTable { tableName =>
-              val updateItem = UpdateItem(
-                key = pk(avi3Item),
-                tableName = TableName(tableName),
-                updateExpression = UpdateExpression($(name).setValue(notAdam))
-              ).transaction.withClientRequestToken("test-token")
+            withDefaultTable {
+              tableName =>
+                val updateItem = UpdateItem(
+                  key = pk(avi3Item),
+                  tableName = TableName(tableName),
+                  updateExpression = UpdateExpression($(name).setValue(notAdam))
+                ).transaction.withClientRequestToken("test-token")
 
-              val updateItem2 = UpdateItem(
-                key = pk(avi3Item),
-                tableName = TableName(tableName),
-                updateExpression = UpdateExpression($(name).setValue("BOOOOOOO"))
-              ).transaction.withClientRequestToken("test-token")
+                val updateItem2 = UpdateItem(
+                  key = pk(avi3Item),
+                  tableName = TableName(tableName),
+                  updateExpression = UpdateExpression($(name).setValue("BOOOOOOO"))
+                ).transaction.withClientRequestToken("test-token")
 
-              val program = for {
-                _ <- updateItem.execute
-                _ <- updateItem2.execute
-              } yield ()
+                val program = for {
+                  _ <- updateItem.execute
+                  _ <- updateItem2.execute
+                } yield ()
 
-              assertM(program.exit)(
-                fails(isSubtype[IdempotentParameterMismatchException](Assertion.anything))
-              )
+                assertM(program.exit)(
+                  fails(isSubtype[IdempotentParameterMismatchException](Assertion.anything))
+                )
             }
           }
         ),
@@ -907,27 +939,28 @@ object LiveSpec extends ZIOSpecDefault {
             }
           },
           test("missing item in other table") {
-            withDefaultTable { tableName =>
-              val secondTable = numberTable("some-table")
-              val getItems    = BatchGetItem().addAll(
-                GetItem(TableName(tableName), pk(avi3Item)),
-                GetItem(TableName(tableName), pk(adam2Item)),
-                GetItem(TableName("some-table"), Item(id -> 5))
-              )
-              for {
-                _ <- secondTable.execute
-                a <- getItems.transaction.execute
-              } yield assert(a)(
-                equalTo(
-                  BatchGetItem.Response(
-                    responses = MapOfSet.apply(
-                      ScalaMap[TableName, Set[Item]](
-                        TableName(tableName) -> Set(avi3Item, adam2Item)
+            withDefaultTable {
+              tableName =>
+                val secondTable = numberTable("some-table")
+                val getItems    = BatchGetItem().addAll(
+                  GetItem(TableName(tableName), pk(avi3Item)),
+                  GetItem(TableName(tableName), pk(adam2Item)),
+                  GetItem(TableName("some-table"), Item(id -> 5))
+                )
+                for {
+                  _ <- secondTable.execute
+                  a <- getItems.transaction.execute
+                } yield assert(a)(
+                  equalTo(
+                    BatchGetItem.Response(
+                      responses = MapOfSet.apply(
+                        ScalaMap[TableName, Set[Item]](
+                          TableName(tableName) -> Set(avi3Item, adam2Item)
+                        )
                       )
                     )
                   )
                 )
-              )
             }
           }
         )

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -589,7 +589,7 @@ case object DynamoDBExecutorImpl {
     ) // TODO(adam): Need a better way to accomplish this
     val keySet =
       ka.keys
-        .map(m => PrimaryKey(m.flatMap { case (k, v) => awsAttrValToAttrVal(v).map(a => (k.toString, a)) }))
+        .map(m => PrimaryKey(m.flatMap { case (k, v) => awsAttrValToAttrVal(v).map((k.toString, _)) }))
         .toSet
 
     maybeProjectionExpressions

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -613,15 +613,19 @@ case object DynamoDBExecutorImpl {
       item.map.flatMap { case (k, v) => awsAttributeValue(v).map(a => (ZIOAwsAttributeName(k.toString), a)) }
   }
 
-  private def awsPutItemRequest(putItem: PutItem): PutItemRequest =
+  private def awsPutItemRequest(putItem: PutItem): PutItemRequest = {
+    val maybeAliasMap = putItem.conditionExpression.map(_.render.execute)
+
     PutItemRequest(
       tableName = ZIOAwsTableName(putItem.tableName.value),
       item = awsAttributeValueMap(putItem.item.map),
       returnConsumedCapacity = Some(awsConsumedCapacity(putItem.capacity)),
       returnItemCollectionMetrics = Some(ReturnItemCollectionMetrics.toZioAws(putItem.itemMetrics)),
-      conditionExpression = putItem.conditionExpression.map(v => ZIOAwsConditionExpression(v.toString)),
+      conditionExpression = maybeAliasMap.map(c => ZIOAwsConditionExpression(c._2)),
+      expressionAttributeValues = maybeAliasMap.flatMap(m => aliasMapToExpressionZIOAwsAttributeValues(m._1)),
       returnValues = Some(awsReturnValues(putItem.returnValues))
     )
+  }
 
   private def awsGetItemRequest(getItem: GetItem): GetItemRequest =
     GetItemRequest(
@@ -652,15 +656,19 @@ case object DynamoDBExecutorImpl {
       returnConsumedCapacity = Some(awsConsumedCapacity(batchGetItem.capacity))
     )
 
-  private def awsDeleteItemRequest(deleteItem: DeleteItem): DeleteItemRequest =
+  private def awsDeleteItemRequest(deleteItem: DeleteItem): DeleteItemRequest = {
+    val maybeAliasMap = deleteItem.conditionExpression.map(_.render.execute)
+
     DeleteItemRequest(
       tableName = ZIOAwsTableName(deleteItem.tableName.value),
       key = deleteItem.key.toZioAwsMap(),
-      conditionExpression = deleteItem.conditionExpression.map(_.toString).map(ZIOAwsConditionExpression(_)),
+      conditionExpression = maybeAliasMap.map(c => ZIOAwsConditionExpression(c._2)),
+      expressionAttributeValues = maybeAliasMap.flatMap(m => aliasMapToExpressionZIOAwsAttributeValues(m._1)),
       returnConsumedCapacity = Some(awsConsumedCapacity(deleteItem.capacity)),
       returnItemCollectionMetrics = Some(awsReturnItemCollectionMetrics(deleteItem.itemMetrics)),
       returnValues = Some(awsReturnValues(deleteItem.returnValues))
     )
+  }
 
   private def awsCreateTableRequest(createTable: CreateTable): CreateTableRequest =
     CreateTableRequest(


### PR DESCRIPTION
Combines two previous PRs for skipping writing empty sets and fixing the batching + condition expression rendering for put + delete items.
