### PR TITLE
Remove Usages Of ZIO.succeedNow

### DIFF
--- a/dynamodb/src/main/scala/zio/dynamodb/package.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/package.scala
@@ -107,7 +107,7 @@ package object dynamodb {
     batchReadItemFromStream(tableName, stream, mPar)(pk).mapZIO {
       case (a, item) =>
         DynamoDBQuery.fromItem(item) match {
-          case Right(b) => ZIO.succeedNow((a, b))
+          case Right(b) => ZIO.succeed((a, b))
           case Left(s)  => ZIO.fail(new IllegalStateException(s)) // TODO: think about error model
         }
     }


### PR DESCRIPTION
This is an internal API that will be deleted at some point.