### PR TITLE
Series/2.x missing proofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -455,6 +455,7 @@ project/plugins/project/
 *.class
 *.log
 
+metals.sbt
 .metals/
 .bloop/
 .bsp/

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -166,7 +166,6 @@ object LiveSpec extends ZIOSpecDefault {
     val (id, num, ttl)  = ProjectionExpression.accessors[ExpressionAttrNames]
   }
 
-
   val mainSuite: Spec[TestEnvironment, Any] =
     suite("live test")(
       suite("debug")(
@@ -187,12 +186,10 @@ object LiveSpec extends ZIOSpecDefault {
           withDefaultTable {
             tableName =>
               val p: ConditionExpression[ExpressionAttrNames] = ExpressionAttrNames.ttl.notExists
-              val query: DynamoDBQuery[
-                ExpressionAttrNames,
-                Either[DynamoDBError, (Chunk[ExpressionAttrNames], Option[AttrMap])]
-              ]                                               = DynamoDBQuery
-                .querySome[ExpressionAttrNames](tableName, 1)
-                .whereKey($("id") === "id") // TODO: use high level API here
+              val query: DynamoDBQuery[ExpressionAttrNames,(Chunk[ExpressionAttrNames], Option[AttrMap])] =
+                DynamoDBQuery
+                  .querySome[ExpressionAttrNames](tableName, 1)
+                  .whereKey($("id") === "id") // TODO: Avi - add extra CanWhereKey proof
 
               query.filter(p)
 

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -171,29 +171,27 @@ object LiveSpec extends ZIOSpecDefault {
       suite("debug")(
         test("scanSomeItem should handle keyword") {
           withDefaultTable { tableName =>
-            val query: DynamoDBQuery[ExpressionAttrNames, (Chunk[ExpressionAttrNames], Option[AttrMap])] =
-              DynamoDBQuery
-                .scanSome[ExpressionAttrNames](tableName, 1)
+            val query = DynamoDBQuery
+              .scanSome[ExpressionAttrNames](tableName, 1)
+              .filter(ExpressionAttrNames.ttl.notExists)
 
-            val p: ConditionExpression[ExpressionAttrNames] = ExpressionAttrNames.ttl.notExists
-            val query2                                      = query.filter(p)
-            query2.execute.exit.map { result =>
-              assert(result.isSuccess)(isTrue)
-            }
+            query.execute
+              .exit
+              .map { result =>
+                assert(result.isSuccess)(isTrue)
+              }
           }
         },
         test("querySome should handle keyword") {
-          withDefaultTable {
-            tableName =>
-              val p: ConditionExpression[ExpressionAttrNames] = ExpressionAttrNames.ttl.notExists
-              val query: DynamoDBQuery[ExpressionAttrNames,(Chunk[ExpressionAttrNames], Option[AttrMap])] =
-                DynamoDBQuery
-                  .querySome[ExpressionAttrNames](tableName, 1)
-                  .whereKey($("id") === "id") // TODO: Avi - add extra CanWhereKey proof
-
-              query.filter(p)
-
-              query.execute.exit.map { result =>
+          withDefaultTable { tableName =>
+            val query = DynamoDBQuery
+              .querySome[ExpressionAttrNames](tableName, 1)
+              .whereKey(ExpressionAttrNames.id === "id")
+              .filter(ExpressionAttrNames.ttl.notExists)
+              
+            query.execute
+              .exit
+              .map { result =>
                 assert(result.isSuccess)(isTrue)
               }
           }

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -168,35 +168,6 @@ object LiveSpec extends ZIOSpecDefault {
 
   val mainSuite: Spec[TestEnvironment, Any] =
     suite("live test")(
-      suite("debug")(
-        test("scanSomeItem should handle keyword") {
-          withDefaultTable { tableName =>
-            val query = DynamoDBQuery
-              .scanSome[ExpressionAttrNames](tableName, 1)
-              .filter(ExpressionAttrNames.ttl.notExists)
-
-            query.execute
-              .exit
-              .map { result =>
-                assert(result.isSuccess)(isTrue)
-              }
-          }
-        },
-        test("querySome should handle keyword") {
-          withDefaultTable { tableName =>
-            val query = DynamoDBQuery
-              .querySome[ExpressionAttrNames](tableName, 1)
-              .whereKey(ExpressionAttrNames.id === "id")
-              .filter(ExpressionAttrNames.ttl.notExists)
-              
-            query.execute
-              .exit
-              .map { result =>
-                assert(result.isSuccess)(isTrue)
-              }
-          }
-        }
-      ),
       suite("keywords in expression attribute names")(
         suite("using high level api")(
           test("scanAll should handle keyword") {
@@ -217,6 +188,29 @@ object LiveSpec extends ZIOSpecDefault {
                 .filter(ExpressionAttrNames.ttl.notExists)
               query.execute.flatMap(_.runDrain).exit.map { result =>
                 assert(result)(succeeds(isUnit))
+              }
+            }
+          },
+          test("scanSome should handle keyword") {
+            withDefaultTable { tableName =>
+              val query = DynamoDBQuery
+                .scanSome[ExpressionAttrNames](tableName, 1)
+                .filter(ExpressionAttrNames.ttl.notExists)
+
+              query.execute.exit.map { result =>
+                assert(result.isSuccess)(isTrue)
+              }
+            }
+          },
+          test("querySome should handle keyword") {
+            withDefaultTable { tableName =>
+              val query = DynamoDBQuery
+                .querySome[ExpressionAttrNames](tableName, 1)
+                .whereKey(ExpressionAttrNames.id === "id")
+                .filter(ExpressionAttrNames.ttl.notExists)
+
+              query.execute.exit.map { result =>
+                assert(result.isSuccess)(isTrue)
               }
             }
           },
@@ -254,10 +248,10 @@ object LiveSpec extends ZIOSpecDefault {
           }
         ),
         suite("using $ function")(
-          test("scanAll should handle keyword") {
+          test("scanAllItem should handle keyword") {
             withDefaultTable { tableName =>
               val query = DynamoDBQuery
-                .scanAll[ExpressionAttrNames](tableName)
+                .scanAllItem(tableName)
                 .filter($("ttl").notExists)
               query.execute.flatMap(_.runDrain).exit.map { result =>
                 assert(result)(succeeds(isUnit))
@@ -294,7 +288,7 @@ object LiveSpec extends ZIOSpecDefault {
               }
             }
           },
-          test("querySome should handle keyword") {
+          test("querySomeItem should handle keyword") {
             withDefaultTable { tableName =>
               val query = DynamoDBQuery
                 .querySomeItem(tableName, 1)
@@ -305,7 +299,7 @@ object LiveSpec extends ZIOSpecDefault {
               }
             }
           },
-          test("querySome should handle keyword in projection") {
+          test("querySomeItem should handle keyword in projection") {
             withDefaultTable { tableName =>
               val query = DynamoDBQuery
                 .querySomeItem(tableName, 1, $("ttl"))

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -196,7 +196,6 @@ object LiveSpec extends ZIOSpecDefault {
               val query = DynamoDBQuery
                 .scanSome[ExpressionAttrNames](tableName, 1)
                 .filter(ExpressionAttrNames.ttl.notExists)
-
               query.execute.exit.map { result =>
                 assert(result.isSuccess)(isTrue)
               }
@@ -208,7 +207,6 @@ object LiveSpec extends ZIOSpecDefault {
                 .querySome[ExpressionAttrNames](tableName, 1)
                 .whereKey(ExpressionAttrNames.id === "id")
                 .filter(ExpressionAttrNames.ttl.notExists)
-
               query.execute.exit.map { result =>
                 assert(result.isSuccess)(isTrue)
               }

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -190,7 +190,6 @@ object LiveSpec extends ZIOSpecDefault {
 
           for {
             result <- query.execute
-            _       = println(result)
           } yield assert(result._1)(hasSize(equalTo(1))) && assert(result._1(0))(
             equalTo(ExpressionAttrNames(second, 2, None))
           ) && assert(result._2)(
@@ -228,29 +227,6 @@ object LiveSpec extends ZIOSpecDefault {
               }
             }
           },
-          // test("scanSome should handle keyword") {
-          //   withDefaultTable { tableName =>
-          //     val query = DynamoDBQuery
-          //       .scanSome[ExpressionAttrNames](tableName, 1)
-          //       .filter(ExpressionAttrNames.ttl.notExists)
-
-          //     for {
-          //       result <- query.execute
-          //       _       = println(s"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX result=$result")
-          //     } yield assertCompletes
-          //   }
-          // },
-          // test("querySome should handle keyword") {
-          //   withDefaultTable { tableName =>
-          //     val query = DynamoDBQuery
-          //       .querySome[ExpressionAttrNames](tableName, 1)
-          //       .whereKey(ExpressionAttrNames.id === "id")
-          //       .filter(ExpressionAttrNames.ttl.notExists)
-          //     query.execute.exit.map { result =>
-          //       assert(result.isSuccess)(isTrue)
-          //     }
-          //   }
-          // },
           test("scanSome should handle keyword") {
             withDefaultTable { tableName =>
               val query = DynamoDBQuery
@@ -274,7 +250,6 @@ object LiveSpec extends ZIOSpecDefault {
 
                 for {
                   result <- query.execute
-                  _       = println(result)
                 } yield assert(result._1)(hasSize(equalTo(1))) && assert(result._1(0))(
                   equalTo(ExpressionAttrNames(second, 2, None))
                 ) && assert(result._2)(

--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -166,42 +166,6 @@ object LiveSpec extends ZIOSpecDefault {
     val (id, num, ttl)  = ProjectionExpression.accessors[ExpressionAttrNames]
   }
 
-  val debugSuite = suite("debug")(
-    test("scanSome should handle keyword") {
-      withDefaultTable { tableName =>
-        val query = DynamoDBQuery
-          .scanSome[ExpressionAttrNames](tableName, 1)
-          .filter(ExpressionAttrNames.ttl.notExists)
-
-        for {
-          result <- query.execute
-        } yield assert(result._1)(hasSize(equalTo(1))) && assert(result._1(0))(
-          equalTo(ExpressionAttrNames(second, 2, None))
-        ) && assert(result._2)(equalTo(Some(PrimaryKey("num" -> 2, "id" -> second))))
-      }
-    },
-    test("querySome should handle keyword2") {
-      withDefaultTable {
-        tableName =>
-          val query = DynamoDBQuery
-            .querySome[ExpressionAttrNames](tableName, 1)
-            .whereKey(PartitionKey(id) === second && SortKey(number) > 0)
-            .filter(ExpressionAttrNames.ttl.notExists)
-
-          for {
-            result <- query.execute
-          } yield assert(result._1)(hasSize(equalTo(1))) && assert(result._1(0))(
-            equalTo(ExpressionAttrNames(second, 2, None))
-          ) && assert(result._2)(
-            equalTo(Some(PrimaryKey("num" -> 2, "id" -> second)))
-          )
-      }
-    }
-  )
-    .provideSomeLayerShared[TestEnvironment](
-      testLayer.orDie
-    ) @@ nondeterministic
-
   val mainSuite: Spec[TestEnvironment, Any] =
     suite("live test")(
       suite("keywords in expression attribute names")(

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -171,7 +171,8 @@ private[dynamodb] final case class DynamoDBExecutorImpl private (dynamoDb: Dynam
       )
       .mapError(_.toThrowable)
 
-  private def executeQuerySome(querySome: QuerySome): ZIO[Any, Throwable, (Chunk[Item], LastEvaluatedKey)] =
+  private def executeQuerySome(querySome: QuerySome): ZIO[Any, Throwable, (Chunk[Item], LastEvaluatedKey)] = {
+    println(s"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX querySome=$querySome")
     dynamoDb
       .queryPaginated(awsQueryRequest(querySome))
       .mapBoth(
@@ -182,6 +183,7 @@ private[dynamodb] final case class DynamoDBExecutorImpl private (dynamoDb: Dynam
             queryResponse.lastEvaluatedKey.map(dynamoDBItem).toOption
           )
       )
+  }
 
   private def executeQueryAll(queryAll: QueryAll): ZIO[Any, Throwable, Stream[Throwable, Item]] =
     ZIO.succeed(

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -171,8 +171,7 @@ private[dynamodb] final case class DynamoDBExecutorImpl private (dynamoDb: Dynam
       )
       .mapError(_.toThrowable)
 
-  private def executeQuerySome(querySome: QuerySome): ZIO[Any, Throwable, (Chunk[Item], LastEvaluatedKey)] = {
-    println(s"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX querySome=$querySome")
+  private def executeQuerySome(querySome: QuerySome): ZIO[Any, Throwable, (Chunk[Item], LastEvaluatedKey)] =
     dynamoDb
       .queryPaginated(awsQueryRequest(querySome))
       .mapBoth(
@@ -183,7 +182,6 @@ private[dynamodb] final case class DynamoDBExecutorImpl private (dynamoDb: Dynam
             queryResponse.lastEvaluatedKey.map(dynamoDBItem).toOption
           )
       )
-  }
 
   private def executeQueryAll(queryAll: QueryAll): ZIO[Any, Throwable, Stream[Throwable, Item]] =
     ZIO.succeed(

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -468,7 +468,7 @@ case object DynamoDBExecutorImpl {
         buildTransaction(query).map {
           case (constructors, construct) => (constructors, chunk => mapper.asInstanceOf[Any => A](construct(chunk)))
         }
-      case Absolve(query)                     =>
+      case Absolve(query)                 =>
         Left(
           InvalidTransactionActions(NonEmptyChunk(query.asInstanceOf[DynamoDBQuery[Any, Any]]))
         )

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -468,10 +468,10 @@ case object DynamoDBExecutorImpl {
         buildTransaction(query).map {
           case (constructors, construct) => (constructors, chunk => mapper.asInstanceOf[Any => A](construct(chunk)))
         }
-      case Absolve(_)                     =>
+      case Absolve(query)                     =>
         Left(
-          new IllegalStateException("Invalid query type Absolve for a transaction")
-        ) // TODO: Avi - create a new DynamDBError constructor for executor impl errors
+          InvalidTransactionActions(NonEmptyChunk(query.asInstanceOf[DynamoDBQuery[Any, Any]]))
+        )
     }
 
   private[dynamodb] def constructTransaction[A](

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -168,7 +168,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
     self match {
       case Zip(left, right, zippable) => Zip(left.metrics(itemMetrics), right.metrics(itemMetrics), zippable)
       case Map(query, mapper)         => Map(query.metrics(itemMetrics), mapper)
-      case Absolve(query)         => Absolve(query.metrics(itemMetrics))
+      case Absolve(query)             => Absolve(query.metrics(itemMetrics))
       case p: PutItem                 =>
         p.copy(itemMetrics = itemMetrics).asInstanceOf[DynamoDBQuery[In, Out]]
       case u: UpdateItem              =>
@@ -207,7 +207,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
         )
       case map @ Map(query, mapper)         =>
         Map(query.filter(filterExpression.asInstanceOf[FilterExpression[map.Old]]), mapper)
-      case ab @ Absolve(query)         =>
+      case ab @ Absolve(query)              =>
         Absolve(query.filter(filterExpression.asInstanceOf[FilterExpression[ab.Old]]))
 
       case s: ScanSome                      => s.copy(filterExpression = Some(filterExpression)).asInstanceOf[DynamoDBQuery[In, Out]]

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -207,7 +207,8 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
         )
       case map @ Map(query, mapper)         =>
         Map(query.filter(filterExpression.asInstanceOf[FilterExpression[map.Old]]), mapper)
-      // TODO: Avi
+      case ab @ Absolve(query)         =>
+        Absolve(query.filter(filterExpression.asInstanceOf[FilterExpression[ab.Old]]))
 
       case s: ScanSome                      => s.copy(filterExpression = Some(filterExpression)).asInstanceOf[DynamoDBQuery[In, Out]]
       case s: ScanAll                       => s.copy(filterExpression = Some(filterExpression)).asInstanceOf[DynamoDBQuery[In, Out]]

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -424,7 +424,7 @@ object DynamoDBQuery {
 
   def fail(e: => DynamoDBError): DynamoDBQuery[Any, Nothing] = Fail(() => e)
 
-  def absolve[A, B](query: DynamoDBQuery[A, Either[DynamoDBError, B]]): DynamoDBQuery[A, B] =
+  private [dynamodb] def absolve[A, B](query: DynamoDBQuery[A, Either[DynamoDBError, B]]): DynamoDBQuery[A, B] =
     Absolve(query)
 
   def fromEither[A](or: Either[DynamoDBError, A]): DynamoDBQuery[Any, A] =
@@ -468,7 +468,6 @@ object DynamoDBQuery {
       case None       => Left(ValueNotFound(s"value with key $key not found"))
     }
 
-  // TODO: Subsume this error DynamoDB
   private[dynamodb] def fromItem[A: Schema](item: Item): Either[DynamoDBError, A] = {
     val av = ToAttributeValue.attrMapToAttributeValue.toAttributeValue(item)
     av.decode(Schema[A])

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -993,8 +993,7 @@ object DynamoDBQuery {
           }
         )
 
-      // TODO: Avi
-      case Absolve(query)     => (Chunk.empty, _ => query.asInstanceOf[A])
+      case Absolve(_)         => (Chunk.empty, _ => ().asInstanceOf[A])
       case Fail(error)        => (Chunk.empty, _ => error().asInstanceOf[A])
 
       case Succeed(value) => (Chunk.empty, _ => value())

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -347,16 +347,16 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
     val keyConditionExpression: KeyConditionExpression =
       KeyConditionExpression.fromConditionExpressionUnsafe(conditionExpression)
     self match {
-      case Zip(left, right, zippable) =>
+      case Zip(left, right, zippable)   =>
         Zip(left.whereKey(keyConditionExpression), right.whereKey(keyConditionExpression), zippable)
-      case Map(query, mapper)         => Map(query.whereKey(keyConditionExpression), mapper)
+      case Map(query, mapper)           => Map(query.whereKey(keyConditionExpression), mapper)
       case DynamoDBQuery.Absolve(query) =>
         DynamoDBQuery.Absolve(query.whereKey(keyConditionExpression))
-      case s: QuerySome               =>
+      case s: QuerySome                 =>
         s.copy(keyConditionExpression = Some(keyConditionExpression)).asInstanceOf[DynamoDBQuery[In, Out]]
-      case s: QueryAll                =>
+      case s: QueryAll                  =>
         s.copy(keyConditionExpression = Some(keyConditionExpression)).asInstanceOf[DynamoDBQuery[In, Out]]
-      case _                          => self
+      case _                            => self
     }
   }
 
@@ -652,7 +652,8 @@ object DynamoDBQuery {
 
   private[dynamodb] final case class Fail(error: () => DynamoDBError) extends Constructor[Any, Nothing]
 
-  private[dynamodb] final case class Absolve[A, B](query: DynamoDBQuery[A, Either[DynamoDBError, B]]) extends DynamoDBQuery[A, B]
+  private[dynamodb] final case class Absolve[A, B](query: DynamoDBQuery[A, Either[DynamoDBError, B]])
+      extends DynamoDBQuery[A, B]
 
   private[dynamodb] final case class GetItem(
     tableName: TableName,

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -249,7 +249,8 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
         )
       case Map(query, mapper)         =>
         Map(query.gsi(indexName, keySchema, projection, readCapacityUnit, writeCapacityUnit), mapper)
-      // TODO: Avi
+      case Absolve(query)             =>
+        Absolve(query.gsi(indexName, keySchema, projection, readCapacityUnit, writeCapacityUnit))
       case s: CreateTable             =>
         s.copy(globalSecondaryIndexes =
           s.globalSecondaryIndexes + GlobalSecondaryIndex(
@@ -275,7 +276,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
           zippable
         )
       case Map(query, mapper)         => Map(query.gsi(indexName, keySchema, projection), mapper)
-      // TODO: Avi
+      case Absolve(query)             => Absolve(query.gsi(indexName, keySchema, projection))
       case s: CreateTable             =>
         s.copy(globalSecondaryIndexes =
           s.globalSecondaryIndexes + GlobalSecondaryIndex(
@@ -297,7 +298,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
       case Zip(left, right, zippable) =>
         Zip(left.lsi(indexName, keySchema, projection), right.lsi(indexName, keySchema, projection), zippable)
       case Map(query, mapper)         => Map(query.lsi(indexName, keySchema, projection), mapper)
-      // TODO: Avi
+      case Absolve(query)             => Absolve(query.lsi(indexName, keySchema, projection))
       case s: CreateTable             =>
         s.copy(localSecondaryIndexes =
           s.localSecondaryIndexes + LocalSecondaryIndex(
@@ -378,7 +379,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
       case Zip(left, right, zippable) =>
         Zip(left.withRetryPolicy(retryPolicy), right.withRetryPolicy(retryPolicy), zippable)
       case Map(query, mapper)         => Map(query.withRetryPolicy(retryPolicy), mapper)
-      // TODO: Avi
+      case Absolve(query)             => Absolve(query.withRetryPolicy(retryPolicy))
       case s: BatchWriteItem          => s.copy(retryPolicy = retryPolicy).asInstanceOf[DynamoDBQuery[In, Out]]
       case s: BatchGetItem            => s.copy(retryPolicy = retryPolicy).asInstanceOf[DynamoDBQuery[In, Out]]
       case _                          => self
@@ -388,7 +389,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
     self match {
       case Zip(left, right, zippable) => Zip(left.sortOrder(ascending), right.sortOrder(ascending), zippable)
       case Map(query, mapper)         => Map(query.sortOrder(ascending), mapper)
-      // TODO: Avi
+      case Absolve(query)             => Absolve(query.sortOrder(ascending))
       case s: QuerySome               => s.copy(ascending = ascending).asInstanceOf[DynamoDBQuery[In, Out]]
       case s: QueryAll                => s.copy(ascending = ascending).asInstanceOf[DynamoDBQuery[In, Out]]
       case _                          => self
@@ -399,7 +400,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
       case Zip(left, right, zippable) =>
         Zip(left.withClientRequestToken(token), right.withClientRequestToken(token), zippable)
       case Map(query, mapper)         => Map(query.withClientRequestToken(token), mapper)
-      // TODO: Avi
+      case Absolve(query)             => Absolve(query.withClientRequestToken(token))
       case s: Transaction[Out]        => s.copy(clientRequestToken = Some(token)).asInstanceOf[DynamoDBQuery[In, Out]]
       case _                          => self
     }
@@ -420,6 +421,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
     self match {
       case Zip(left, right, zippable) => Zip(left.select(select), right.select(select), zippable)
       case Map(query, mapper)         => Map(query.select(select), mapper)
+      case Absolve(query)             => Absolve(query.select(select))
       case s: ScanSome                => s.copy(select = Some(select)).asInstanceOf[DynamoDBQuery[In, Out]]
       case s: ScanAll                 => s.copy(select = Some(select)).asInstanceOf[DynamoDBQuery[In, Out]]
       case s: QuerySome               => s.copy(select = Some(select)).asInstanceOf[DynamoDBQuery[In, Out]]

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -168,7 +168,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
     self match {
       case Zip(left, right, zippable) => Zip(left.metrics(itemMetrics), right.metrics(itemMetrics), zippable)
       case Map(query, mapper)         => Map(query.metrics(itemMetrics), mapper)
-      // TODO: Avi
+      case Absolve(query)         => Absolve(query.metrics(itemMetrics))
       case p: PutItem                 =>
         p.copy(itemMetrics = itemMetrics).asInstanceOf[DynamoDBQuery[In, Out]]
       case u: UpdateItem              =>
@@ -185,7 +185,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
       case Zip(left, right, zippable) =>
         Zip(left.startKey(exclusiveStartKey), right.startKey(exclusiveStartKey), zippable)
       case Map(query, mapper)         => Map(query.startKey(exclusiveStartKey), mapper)
-      // TODO: Avi
+      case Absolve(query)             => Absolve(query.startKey(exclusiveStartKey))
       case s: ScanSome                => s.copy(exclusiveStartKey = exclusiveStartKey).asInstanceOf[DynamoDBQuery[In, Out]]
       case s: ScanAll                 => s.copy(exclusiveStartKey = exclusiveStartKey).asInstanceOf[DynamoDBQuery[In, Out]]
       case s: QuerySome               => s.copy(exclusiveStartKey = exclusiveStartKey).asInstanceOf[DynamoDBQuery[In, Out]]

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -568,14 +568,16 @@ object DynamoDBQuery {
     tableName: String,
     limit: Int,
     projections: ProjectionExpression[_, _]*
-  ): DynamoDBQuery[A, Either[DynamoDBError, (Chunk[A], LastEvaluatedKey)]] =
-    querySomeItem(tableName, limit, projections: _*).map {
-      case (itemsChunk, lek) =>
-        EitherUtil.forEach(itemsChunk)(item => fromItem(item)).map(Chunk.fromIterable) match {
-          case Right(chunk) => Right((chunk, lek))
-          case Left(error)  => Left(error)
-        }
-    }
+  ): DynamoDBQuery[A, (Chunk[A], LastEvaluatedKey)] =
+    DynamoDBQuery.absolve(
+      querySomeItem(tableName, limit, projections: _*).map {
+        case (itemsChunk, lek) =>
+          EitherUtil.forEach(itemsChunk)(item => fromItem(item)).map(Chunk.fromIterable) match {
+            case Right(chunk) => Right((chunk, lek))
+            case Left(error)  => Left(error)
+          }
+      }
+    )
 
   /**
    * when executed will return a ZStream of Item

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -424,7 +424,7 @@ object DynamoDBQuery {
 
   def fail(e: => DynamoDBError): DynamoDBQuery[Any, Nothing] = Fail(() => e)
 
-  private [dynamodb] def absolve[A, B](query: DynamoDBQuery[A, Either[DynamoDBError, B]]): DynamoDBQuery[A, B] =
+  private[dynamodb] def absolve[A, B](query: DynamoDBQuery[A, Either[DynamoDBError, B]]): DynamoDBQuery[A, B] =
     Absolve(query)
 
   def fromEither[A](or: Either[DynamoDBError, A]): DynamoDBQuery[Any, A] =

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -329,15 +329,10 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
       case Absolve(query)             => Absolve(query.whereKey(keyConditionExpression))
 
       case s: QuerySome =>
-        val x = s.copy(keyConditionExpression = Some(keyConditionExpression)).asInstanceOf[DynamoDBQuery[In, Out]]
-        println(s"whereKey XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX $x")
-        x
+        s.copy(keyConditionExpression = Some(keyConditionExpression)).asInstanceOf[DynamoDBQuery[In, Out]]
       case s: QueryAll  =>
         s.copy(keyConditionExpression = Some(keyConditionExpression)).asInstanceOf[DynamoDBQuery[In, Out]]
-//      case _                          =>
-      case q            =>
-        println(s"whereKey XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX case _ query=$q")
-        self
+      case _            => self
     }
 
   /**
@@ -1031,7 +1026,6 @@ object DynamoDBQuery {
         parallelize(absolved)
 
       case Fail(error)        =>
-        println("YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY")
         (Chunk.empty, _ => error().asInstanceOf[A])
 
       case Succeed(value)     => (Chunk.empty, _ => value())

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -228,7 +228,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
     self match {
       case Zip(left, right, zippable) => Zip(left.parallel(n), right.parallel(n), zippable)
       case Map(query, mapper)         => Map(query.parallel(n), mapper)
-      // TODO: Avi
+      case Absolve(query)             => Absolve(query.parallel(n))
       case s: ScanAll                 => s.copy(totalSegments = n).asInstanceOf[DynamoDBQuery[In, Out]]
       case _                          => self
     }

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -152,6 +152,8 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
         )
       case map @ Map(query, mapper)         =>
         Map(query.where(conditionExpression.asInstanceOf[ConditionExpression[map.Old]]), mapper)
+      case ab @ Absolve(query)              =>
+        Absolve(query.where(conditionExpression.asInstanceOf[ConditionExpression[ab.Old]]))
       case p: PutItem                       =>
         p.copy(conditionExpression = Some(conditionExpression)).asInstanceOf[DynamoDBQuery[In, Out]]
       case u: UpdateItem                    =>
@@ -946,7 +948,9 @@ object DynamoDBQuery {
   }
 
   private[dynamodb] final case class Absolve[A, B](query: DynamoDBQuery[A, Either[DynamoDBError, B]])
-      extends DynamoDBQuery[A, B]
+      extends DynamoDBQuery[A, B] {
+    type Old = Either[DynamoDBError, B]
+  }
 
   def apply[A](a: => A): DynamoDBQuery[Any, A] = Succeed(() => a)
 

--- a/dynamodb/src/main/scala/zio/dynamodb/proofs/CanFilter.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/proofs/CanFilter.scala
@@ -2,20 +2,49 @@ package zio.dynamodb.proofs
 
 import zio.stream.Stream
 import scala.annotation.implicitNotFound
+import zio.dynamodb.DynamoDBError
+import zio.dynamodb.LastEvaluatedKey
+import zio.Chunk
 
 @implicitNotFound(
   "Mixed types for the filter expression found - ${A}"
 )
 sealed trait CanFilter[A, -B]
 
-// create lowPriorityCanFilter, prefer Stream one
-object CanFilter {
+trait CanFilterLowpriorityImplicits0 extends CanFilterLowpriorityImplicits1 {
   implicit def subtypeCanFilter[A, B](implicit ev: B <:< A): CanFilter[A, B] = {
     val _ = ev
     new CanFilter[A, B] {}
   }
+}
+trait CanFilterLowpriorityImplicits1 {
   implicit def subtypeStreamCanFilter[A, B](implicit ev: CanFilter[A, B]): CanFilter[A, Stream[Throwable, B]] = {
     val _ = ev
     new CanFilter[A, Stream[Throwable, B]] {}
   }
 }
+// create lowPriorityCanFilter, prefer Stream one
+object CanFilter                     extends CanFilterLowpriorityImplicits0 {
+  implicit def subtypeEitherCanFilter[A](implicit
+    ev: CanFilter[A, _]
+  ): CanFilter[A, Either[DynamoDBError, (Chunk[A], LastEvaluatedKey)]] = {
+    val _ = ev
+    new CanFilter[A, Either[DynamoDBError, (Chunk[A], LastEvaluatedKey)]] {}
+  }
+}
+/*
+@implicitNotFound("DynamoDB does not support 'contains' on type ${A}. This operator only applies to sets and strings")
+sealed trait Containable[X, -A]
+trait ContainableLowPriorityImplicits0 extends ContainableLowPriorityImplicits1 {
+  implicit def unknownRight[X]: Containable[X, ProjectionExpression.Unknown] =
+    new Containable[X, ProjectionExpression.Unknown] {}
+}
+trait ContainableLowPriorityImplicits1 {
+  implicit def set[A]: Containable[Set[A], A]      = new Containable[Set[A], A] {}
+  implicit def string: Containable[String, String] = new Containable[String, String] {}
+}
+object Containable                     extends ContainableLowPriorityImplicits0 {
+  implicit def unknownLeft[X]: Containable[ProjectionExpression.Unknown, X] =
+    new Containable[ProjectionExpression.Unknown, X] {}
+}
+ */

--- a/dynamodb/src/main/scala/zio/dynamodb/proofs/CanFilter.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/proofs/CanFilter.scala
@@ -3,7 +3,7 @@ package zio.dynamodb.proofs
 import zio.stream.Stream
 import scala.annotation.implicitNotFound
 import zio.Chunk
-import zio.dynamodb.AttrMap
+import zio.dynamodb.LastEvaluatedKey
 
 @implicitNotFound(
   "Mixed types for the filter expression found - ${A}"
@@ -17,8 +17,8 @@ trait CanFilterLowpriorityImplicits {
   }
 }
 object CanFilter extends CanFilterLowpriorityImplicits {
-  implicit def scanAndQuerySomeCanFilter[A]: CanFilter[A, (Chunk[A], Option[AttrMap])] =
-    new CanFilter[A, (Chunk[A], Option[AttrMap])] {}
+  implicit def scanAndQuerySomeCanFilter[A]: CanFilter[A, (Chunk[A], LastEvaluatedKey)] =
+    new CanFilter[A, (Chunk[A], LastEvaluatedKey)] {}
 
   implicit def subtypeStreamCanFilter[A, B](implicit ev: CanFilter[A, B]): CanFilter[A, Stream[Throwable, B]] = {
     val _ = ev

--- a/dynamodb/src/main/scala/zio/dynamodb/proofs/CanFilter.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/proofs/CanFilter.scala
@@ -2,12 +2,8 @@ package zio.dynamodb.proofs
 
 import zio.stream.Stream
 import scala.annotation.implicitNotFound
-import zio.dynamodb.DynamoDBError
 import zio.Chunk
 import zio.dynamodb.AttrMap
-// import zio.dynamodb.DynamoDBError
-// import zio.dynamodb.LastEvaluatedKey
-// import zio.Chunk
 
 @implicitNotFound(
   "Mixed types for the filter expression found - ${A}"
@@ -15,39 +11,17 @@ import zio.dynamodb.AttrMap
 sealed trait CanFilter[A, -B]
 
 trait CanFilterLowpriorityImplicits {
-  // 1.
   implicit def subtypeCanFilter[A, B](implicit ev: B <:< A): CanFilter[A, B] = {
     val _ = ev
     new CanFilter[A, B] {}
   }
 }
 object CanFilter extends CanFilterLowpriorityImplicits {
-  implicit def scanSomeCanFilter[A]: CanFilter[A, Either[DynamoDBError, (Chunk[A], Option[AttrMap])]] =
-    new CanFilter[A, Either[DynamoDBError, (Chunk[A], Option[AttrMap])]] {}
-
-  implicit def querySomeCanFilter[A]: CanFilter[A, (Chunk[A], Option[AttrMap])] =
+  implicit def scanAndQuerySomeCanFilter[A]: CanFilter[A, (Chunk[A], Option[AttrMap])] =
     new CanFilter[A, (Chunk[A], Option[AttrMap])] {}
 
-
-  // 2.
   implicit def subtypeStreamCanFilter[A, B](implicit ev: CanFilter[A, B]): CanFilter[A, Stream[Throwable, B]] = {
     val _ = ev
     new CanFilter[A, Stream[Throwable, B]] {}
   }
 }
-/*
-@implicitNotFound("DynamoDB does not support 'contains' on type ${A}. This operator only applies to sets and strings")
-sealed trait Containable[X, -A]
-trait ContainableLowPriorityImplicits0 extends ContainableLowPriorityImplicits1 {
-  implicit def unknownRight[X]: Containable[X, ProjectionExpression.Unknown] =
-    new Containable[X, ProjectionExpression.Unknown] {}
-}
-trait ContainableLowPriorityImplicits1 {
-  implicit def set[A]: Containable[Set[A], A]      = new Containable[Set[A], A] {}
-  implicit def string: Containable[String, String] = new Containable[String, String] {}
-}
-object Containable                     extends ContainableLowPriorityImplicits0 {
-  implicit def unknownLeft[X]: Containable[ProjectionExpression.Unknown, X] =
-    new Containable[ProjectionExpression.Unknown, X] {}
-}
- */

--- a/dynamodb/src/main/scala/zio/dynamodb/proofs/CanWhereKey.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/proofs/CanWhereKey.scala
@@ -3,7 +3,7 @@ package zio.dynamodb.proofs
 import zio.stream.Stream
 import scala.annotation.implicitNotFound
 import zio.Chunk
-import zio.dynamodb.AttrMap
+import zio.dynamodb.LastEvaluatedKey
 
 @implicitNotFound(
   "Mixed types for the key condition expression found - ${A}"
@@ -19,8 +19,8 @@ trait CanWhereKeyLowerPriorityImplicit {
 
 object CanWhereKey extends CanWhereKeyLowerPriorityImplicit {
 
-  implicit def scanAndQuerySomeCanWhereKey[A]: CanWhereKey[A, (Chunk[A], Option[AttrMap])] =
-    new CanWhereKey[A, (Chunk[A], Option[AttrMap])] {}
+  implicit def scanAndQuerySomeCanWhereKey[A]: CanWhereKey[A, (Chunk[A], LastEvaluatedKey)] =
+    new CanWhereKey[A, (Chunk[A], LastEvaluatedKey)] {}
 
   implicit def subtypeStreamCanWhereKey[A, B](implicit ev: CanWhereKey[A, B]): CanWhereKey[A, Stream[Throwable, B]] = {
     val _ = ev

--- a/dynamodb/src/main/scala/zio/dynamodb/proofs/CanWhereKey.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/proofs/CanWhereKey.scala
@@ -10,11 +10,14 @@ import zio.dynamodb.AttrMap
 )
 sealed trait CanWhereKey[A, -B]
 
-object CanWhereKey {
+trait CanWhereKeyLowerPriorityImplicit {
   implicit def subtypeCanWhereKey[A, B](implicit ev: B <:< A): CanWhereKey[A, B] = {
     val _ = ev
     new CanWhereKey[A, B] {}
   }
+}
+
+object CanWhereKey extends CanWhereKeyLowerPriorityImplicit {
 
   implicit def scanAndQuerySomeCanWhereKey[A]: CanWhereKey[A, (Chunk[A], Option[AttrMap])] =
     new CanWhereKey[A, (Chunk[A], Option[AttrMap])] {}

--- a/dynamodb/src/main/scala/zio/dynamodb/proofs/CanWhereKey.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/proofs/CanWhereKey.scala
@@ -2,6 +2,8 @@ package zio.dynamodb.proofs
 
 import zio.stream.Stream
 import scala.annotation.implicitNotFound
+import zio.Chunk
+import zio.dynamodb.AttrMap
 
 @implicitNotFound(
   "Mixed types for the key condition expression found - ${A}"
@@ -9,11 +11,15 @@ import scala.annotation.implicitNotFound
 sealed trait CanWhereKey[A, -B]
 
 object CanWhereKey {
-  implicit def subtypeCanFilter[A, B](implicit ev: B <:< A): CanWhereKey[A, B] = {
+  implicit def subtypeCanWhereKey[A, B](implicit ev: B <:< A): CanWhereKey[A, B] = {
     val _ = ev
     new CanWhereKey[A, B] {}
   }
-  implicit def subtypeStreamCanFilter[A, B](implicit ev: CanWhereKey[A, B]): CanWhereKey[A, Stream[Throwable, B]] = {
+
+  implicit def scanAndQuerySomeCanWhereKey[A]: CanWhereKey[A, (Chunk[A], Option[AttrMap])] =
+    new CanWhereKey[A, (Chunk[A], Option[AttrMap])] {}
+
+  implicit def subtypeStreamCanWhereKey[A, B](implicit ev: CanWhereKey[A, B]): CanWhereKey[A, Stream[Throwable, B]] = {
     val _ = ev
     new CanWhereKey[A, Stream[Throwable, B]] {}
   }


### PR DESCRIPTION
Adds missing proofs for `scanSome` and `querySome` methods in the type safe API.

Also simplifies the signatures for the above methods from `DynamoDBQuery[A, Either[DynamoDBError, (Chunk[A], LastEvaluatedKey)]]` to `DynamoDBQuery[A, (Chunk[A], LastEvaluatedKey)]` by absolving the Left of the Either to improve ergonomics