### PR TITLE
do not batch if projections do not contain PK

### DIFF
--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -650,6 +650,14 @@ object LiveSpec extends ZIOSpecDefault {
             )
           }
         },
+        test("should get item when projections are present but are missing all primary key attributes") {
+          withDefaultTable { tableName =>
+            for {
+              _     <- putItem(tableName, Item(id -> "1", number -> 1, "field1" -> "field1Value")).execute
+              found <- getItem(tableName, PrimaryKey(id -> "1", number -> 1), $("field1")).execute
+            } yield assert(found)(isSome(equalTo(Item("field1" -> "field1Value"))))
+          }
+        },
         suite("SortKeyCondition")(
           test("SortKeyCondition between") {
             withDefaultTable { tableName =>

--- a/dynamodb/src/test/scala/zio/dynamodb/ZStreamPipeliningSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/ZStreamPipeliningSpec.scala
@@ -28,7 +28,7 @@ object ZStreamPipeliningSpec extends ZIOSpecDefault {
           xs          <- batchReadFromStream[Any, Person, Person]("person", personStream)(person =>
                            PrimaryKey("id" -> person.id)
                          ).right.runCollect
-          actualPeople = xs.toList.map(_._2).collect { case Some(b) => b }
+          actualPeople = xs.toList.map { case (_, p) => p }.collect { case Some(b) => b }
         } yield assert(actualPeople)(equalTo(people))
       },
       test(


### PR DESCRIPTION
Fixes #207 

A consequence of this fix is that GetItem queries that have projection that do not contain the primary key will not be eligible for automatic batching, instead it will be automatically executed in parallel if there are other queries. This is reasonable as if primary key data does not exist then the item can not be retrieved from the batched response data.