### PR TITLE
Series/2.x rename delete to deleteFrom

### DIFF
--- a/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/LiveSpec.scala
@@ -313,7 +313,7 @@ object LiveSpec extends ZIOSpecDefault {
           test("delete should handle keyword") {
             withDefaultTable { tableName =>
               val query = DynamoDBQuery
-                .delete(tableName)(
+                .deleteFrom(tableName)(
                   ExpressionAttrNames.id.partitionKey === "id" && ExpressionAttrNames.num.sortKey === 1
                 )
                 .where(ExpressionAttrNames.ttl.notExists)
@@ -1316,7 +1316,7 @@ object LiveSpec extends ZIOSpecDefault {
           },
           test("delete item handles keyword") {
             withDefaultTable { tableName =>
-              val d = delete(tableName = tableName)(
+              val d = deleteFrom(tableName = tableName)(
                 primaryKeyExpr =
                   ExpressionAttrNames.id.partitionKey === "first" && ExpressionAttrNames.num.sortKey === 7
               ).where(ExpressionAttrNames.ttl.notExists)

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -504,7 +504,7 @@ object DynamoDBQuery {
     updateItem(tableName, primaryKeyExpr.asAttrMap)(action).map(_.flatMap(item => fromItem(item).toOption))
   def deleteItem(tableName: String, key: PrimaryKey): Write[Any, Option[Item]] = DeleteItem(TableName(tableName), key)
 
-  def delete[From: Schema](
+  def deleteFrom[From: Schema](
     tableName: String
   )(
     primaryKeyExpr: KeyConditionExpr.PrimaryKeyExpr[From]

--- a/examples/src/main/scala/zio/dynamodb/examples/dynamodblocal/StudentZioDynamoDbExampleWithOptics.scala
+++ b/examples/src/main/scala/zio/dynamodb/examples/dynamodblocal/StudentZioDynamoDbExampleWithOptics.scala
@@ -55,7 +55,7 @@ object StudentZioDynamoDbExampleWithOptics extends ZIOAppDefault {
                Some(Address("line1", "postcode1"))
              )
          }.execute
-    _ <- delete("student")(primaryKey("adam@gmail.com", "english"))
+    _ <- deleteFrom("student")(primaryKey("adam@gmail.com", "english"))
            .where(
              enrollmentDate === Some(
                enrolDate

--- a/examples/src/main/scala/zio/dynamodb/examples/dynamodblocal/StudentZioDynamoDbTypeSafeAPIExample.scala
+++ b/examples/src/main/scala/zio/dynamodb/examples/dynamodblocal/StudentZioDynamoDbTypeSafeAPIExample.scala
@@ -78,7 +78,7 @@ object StudentZioDynamoDbTypeSafeAPIExample extends ZIOAppDefault {
            addresses.remove(1)
          }.execute
     _ <-
-      delete("student")(primaryKey("adam@gmail.com", "english"))
+      deleteFrom("student")(primaryKey("adam@gmail.com", "english"))
         .where(
           (enrollmentDate === Some(enrolDate) && payment <> Payment.PayPal && studentNumber
             .between(1, 3) && groups.contains("group1") && collegeName.contains(


### PR DESCRIPTION
rename `delete` Query in high level API to `deleteFrom` as `delete` implies deleting the whole table.