### PR TITLE
Series/2.x derive projections

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,4 +7,4 @@ services:
     restart: always
     ports:
       - 8000:8000
-    command: "-jar DynamoDBLocal.jar -inMemory"
+    command: "-jar DynamoDBLocal.jar -inMemory -sharedDb"

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -525,11 +525,10 @@ object DynamoDBQuery {
 
   def scanSome[A: Schema](
     tableName: String,
-    limit: Int,
-    projections: ProjectionExpression[_, _]*
+    limit: Int
   ): DynamoDBQuery[A, (Chunk[A], LastEvaluatedKey)] =
     DynamoDBQuery.absolve(
-      scanSomeItem(tableName, limit, projections: _*).map {
+      scanSomeItem(tableName, limit, ProjectionExpression.projectionsFromSchema: _*).map {
         case (itemsChunk, lek) =>
           itemsChunk.forEach(item => fromItem(item)).map(Chunk.fromIterable) match {
             case Right(chunk) => Right((chunk, lek))
@@ -552,10 +551,9 @@ object DynamoDBQuery {
    * when executed will return a ZStream of A
    */
   def scanAll[A: Schema](
-    tableName: String,
-    projections: ProjectionExpression[_, _]*
+    tableName: String
   ): DynamoDBQuery[A, Stream[Throwable, A]] =
-    scanAllItem(tableName, projections: _*).map(
+    scanAllItem(tableName, ProjectionExpression.projectionsFromSchema: _*).map(
       _.mapZIO(item => ZIO.fromEither(fromItem(item)).mapError(new IllegalStateException(_)))
     ) // TODO: think about error model
 
@@ -575,11 +573,10 @@ object DynamoDBQuery {
    */
   def querySome[A: Schema](
     tableName: String,
-    limit: Int,
-    projections: ProjectionExpression[_, _]*
+    limit: Int
   ): DynamoDBQuery[A, (Chunk[A], LastEvaluatedKey)] =
     DynamoDBQuery.absolve(
-      querySomeItem(tableName, limit, projections: _*).map {
+      querySomeItem(tableName, limit, ProjectionExpression.projectionsFromSchema: _*).map {
         case (itemsChunk, lek) =>
           itemsChunk.forEach(item => fromItem(item)).map(Chunk.fromIterable) match {
             case Right(chunk) => Right((chunk, lek))
@@ -604,9 +601,8 @@ object DynamoDBQuery {
   def queryAll[A: Schema](
     tableName: String,
     //keyConditionExpression: KeyConditionExpression, REVIEW: This is required by the dynamo API, should we make it required here?
-    projections: ProjectionExpression[_, _]*
   ): DynamoDBQuery[A, Stream[Throwable, A]] =
-    queryAllItem(tableName, projections: _*).map(
+    queryAllItem(tableName, ProjectionExpression.projectionsFromSchema: _*).map(
       _.mapZIO(item => ZIO.fromEither(fromItem(item)).mapError(new IllegalStateException(_)))
     ) // TODO: think about error model
 

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -454,11 +454,8 @@ object DynamoDBQuery {
 
   def get[From: Schema](tableName: String)(
     primaryKeyExpr: KeyConditionExpr.PrimaryKeyExpr[From]
-  ): DynamoDBQuery[From, Either[DynamoDBError, From]] = {
-    val projections = ProjectionExpression.projectionsFromSchema[From]
-    println(s"XXXXXXXXXXXXXXXXXXX projections=$projections")
-    get(tableName, primaryKeyExpr.asAttrMap, projections)
-  }
+  ): DynamoDBQuery[From, Either[DynamoDBError, From]] =
+    get(tableName, primaryKeyExpr.asAttrMap, ProjectionExpression.projectionsFromSchema[From])
 
   private def get[A: Schema](
     tableName: String,

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -599,7 +599,7 @@ object DynamoDBQuery {
    * when executed will return a ZStream of A
    */
   def queryAll[A: Schema](
-    tableName: String,
+    tableName: String
     //keyConditionExpression: KeyConditionExpression, REVIEW: This is required by the dynamo API, should we make it required here?
   ): DynamoDBQuery[A, Stream[Throwable, A]] =
     queryAllItem(tableName, ProjectionExpression.projectionsFromSchema: _*).map(

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -452,18 +452,18 @@ object DynamoDBQuery {
   ): DynamoDBQuery[Any, Option[Item]] =
     GetItem(TableName(tableName), key, projections.toList)
 
-  def get[From: Schema](
-    tableName: String,
-    projections: ProjectionExpression[_, _]*
-  )(
+  def get[From: Schema](tableName: String)(
     primaryKeyExpr: KeyConditionExpr.PrimaryKeyExpr[From]
-  ): DynamoDBQuery[From, Either[DynamoDBError, From]] =
-    get(tableName, primaryKeyExpr.asAttrMap, projections: _*)
+  ): DynamoDBQuery[From, Either[DynamoDBError, From]] = {
+    val projections = ProjectionExpression.projectionsFromSchema[From]
+    println(s"XXXXXXXXXXXXXXXXXXX projections=$projections")
+    get(tableName, primaryKeyExpr.asAttrMap, projections)
+  }
 
   private def get[A: Schema](
     tableName: String,
     key: PrimaryKey,
-    projections: ProjectionExpression[_, _]*
+    projections: Chunk[ProjectionExpression[_, _]]
   ): DynamoDBQuery[A, Either[DynamoDBError, A]] =
     getItem(tableName, key, projections: _*).map {
       case Some(item) =>

--- a/dynamodb/src/main/scala/zio/dynamodb/ProjectionExpression.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/ProjectionExpression.scala
@@ -912,4 +912,14 @@ object ProjectionExpression extends ProjectionExpressionLowPriorityImplicits0 {
       builder.either.left.map(_.mkString(","))
     }
   }
+
+  def projectionsFromSchema[A: Schema]: Chunk[ProjectionExpression[_, _]] =
+    implicitly[Schema[A]] match {
+      case r: Schema.Record[A] =>
+        r.fields.map { f =>
+          ProjectionExpression.MapElement(Root, f.name)
+        }
+      case _                   => Chunk.empty
+    }
+
 }


### PR DESCRIPTION
Derive projections from Schema in the high level API - narrowing data to just the attributes required is important for reducing network latency. This has now been automated for the high level API.

Also an improvement to the docker file to make the in memory DB shared so that it can be queried with the AWS CLI  