### PR TITLE
add `maybeFound` convenience extension method

### DIFF
--- a/dynamodb/src/it/scala/zio/dynamodb/TypeSafeApiCrudSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/TypeSafeApiCrudSpec.scala
@@ -6,6 +6,7 @@ import zio.test.assertTrue
 import zio.test.Assertion._
 import zio.dynamodb.DynamoDBError.ItemError
 import zio.dynamodb.DynamoDBQuery.{ deleteFrom, forEach, get, put, scanAll, update }
+import zio.dynamodb.syntax._
 import zio.Chunk
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
 import zio.stream.ZStream

--- a/dynamodb/src/it/scala/zio/dynamodb/TypeSafeApiCrudSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/TypeSafeApiCrudSpec.scala
@@ -51,6 +51,16 @@ object TypeSafeApiCrudSpec extends DynamoDBLocalSpec {
           } yield assertTrue(p == person)
         }
       },
+      test("and get simple round trip 2") {
+        import zio.dynamodb.MaybeFound
+        withSingleIdKeyTable { tableName =>
+          val person = Person("1", "Smith", Some("John"), 21)
+          for {
+            _ <- put(tableName, person).execute
+            x <- get(tableName)(Person.id.partitionKey === "1").execute.maybeFound
+          } yield assertTrue(x == Some(person))
+        }
+      },
       test("with condition expression that id not exists fails when item exists") {
         withSingleIdKeyTable { tableName =>
           val person = Person("1", "Smith", Some("John"), 21)

--- a/dynamodb/src/it/scala/zio/dynamodb/TypeSafeApiCrudSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/TypeSafeApiCrudSpec.scala
@@ -51,14 +51,13 @@ object TypeSafeApiCrudSpec extends DynamoDBLocalSpec {
           } yield assertTrue(p == person)
         }
       },
-      test("and get simple round trip 2") {
-        import zio.dynamodb.MaybeFound
+      test("and get simple round using maybeFound extension method") {
         withSingleIdKeyTable { tableName =>
           val person = Person("1", "Smith", Some("John"), 21)
           for {
-            _ <- put(tableName, person).execute
-            x <- get(tableName)(Person.id.partitionKey === "1").execute.maybeFound
-          } yield assertTrue(x == Some(person))
+            _           <- put(tableName, person).execute
+            maybePerson <- get(tableName)(Person.id.partitionKey === "1").execute.maybeFound
+          } yield assertTrue(maybePerson == Some(person))
         }
       },
       test("with condition expression that id not exists fails when item exists") {

--- a/dynamodb/src/main/scala/zio/dynamodb/package.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/package.scala
@@ -22,8 +22,8 @@ package object dynamodb {
   /**
    * Moves ItemError.DecodingError to error channel and effectively does a ZIO option in other cases
    */
-  implicit class MaybeFound[A](zio: ZIO[DynamoDBExecutor, DynamoDBError, Either[ItemError, A]]) {
-    def maybeFound: ZIO[DynamoDBExecutor, DynamoDBError, Option[A]] =
+  implicit class MaybeFound[R, A](zio: ZIO[R, DynamoDBError, Either[ItemError, A]]) {
+    def maybeFound: ZIO[R, DynamoDBError, Option[A]] =
       zio.flatMap {
         case Left(e @ ItemError.DecodingError(_)) => ZIO.fail(e)
         case Left(ItemError.ValueNotFound(_))     => ZIO.succeed(None)

--- a/dynamodb/src/main/scala/zio/dynamodb/package.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/package.scala
@@ -19,10 +19,12 @@ package object dynamodb {
   type Encoder[A]  = A => AttributeValue
   type Decoder[+A] = AttributeValue => Either[ItemError, A]
 
-  /**
-   * Moves ItemError.DecodingError to error channel and effectively does a ZIO option in other cases
-   */
   implicit class MaybeFound[R, A](zio: ZIO[R, DynamoDBError, Either[ItemError, A]]) {
+
+    /**
+     * Moves Left[ItemError.DecodingError] to the error channel and returns Some(a) if the item is found else None
+     * eg {{{ DynamoDBQuery.get("table")(Person.id.partitionKey === 1).execeute.maybeFound }}}
+     */
     def maybeFound: ZIO[R, DynamoDBError, Option[A]] =
       zio.flatMap {
         case Left(e @ ItemError.DecodingError(_)) => ZIO.fail(e)

--- a/dynamodb/src/main/scala/zio/dynamodb/package.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/package.scala
@@ -23,7 +23,7 @@ package object dynamodb {
 
     /**
      * Moves Left[ItemError.DecodingError] to the error channel and returns Some(a) if the item is found else None
-     * eg {{{ DynamoDBQuery.get("table")(Person.id.partitionKey === 1).execeute.maybeFound }}}
+     * eg {{{ DynamoDBQuery.get("table")(Person.id.partitionKey === 1).execute.maybeFound }}}
      */
     def maybeFound: ZIO[R, DynamoDBError, Option[A]] =
       zio.flatMap {

--- a/dynamodb/src/main/scala/zio/dynamodb/package.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/package.scala
@@ -19,20 +19,6 @@ package object dynamodb {
   type Encoder[A]  = A => AttributeValue
   type Decoder[+A] = AttributeValue => Either[ItemError, A]
 
-  implicit class MaybeFound[R, A](zio: ZIO[R, DynamoDBError, Either[ItemError, A]]) {
-
-    /**
-     * Moves Left[ItemError.DecodingError] to the error channel and returns Some(a) if the item is found else None
-     * eg {{{ DynamoDBQuery.get("table")(Person.id.partitionKey === 1).execute.maybeFound }}}
-     */
-    def maybeFound: ZIO[R, DynamoDBError, Option[A]] =
-      zio.flatMap {
-        case Left(e @ ItemError.DecodingError(_)) => ZIO.fail(e)
-        case Left(ItemError.ValueNotFound(_))     => ZIO.succeed(None)
-        case Right(a)                             => ZIO.succeed(Some(a))
-      }
-  }
-
   private[dynamodb] def ddbExecute[A](query: DynamoDBQuery[_, A]): ZIO[DynamoDBExecutor, DynamoDBError, A] =
     ZIO.serviceWithZIO[DynamoDBExecutor](_.execute(query))
 

--- a/dynamodb/src/main/scala/zio/dynamodb/syntax.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/syntax.scala
@@ -1,0 +1,20 @@
+package zio.dynamodb
+
+import zio.ZIO
+
+object syntax {
+  implicit class MaybeFound[R, A](zio: ZIO[R, DynamoDBError, Either[DynamoDBError.ItemError, A]]) {
+
+    /**
+     * Moves Left[ItemError.DecodingError] to the error channel and returns Some(a) if the item is found else None
+     * eg {{{ DynamoDBQuery.get("table")(Person.id.partitionKey === 1).execute.maybeFound }}}
+     */
+    def maybeFound: ZIO[R, DynamoDBError, Option[A]] =
+      zio.flatMap {
+        case Left(e @ DynamoDBError.ItemError.DecodingError(_)) => ZIO.fail(e)
+        case Left(DynamoDBError.ItemError.ValueNotFound(_))     => ZIO.succeed(None)
+        case Right(a)                             => ZIO.succeed(Some(a))
+      }
+  }
+  
+}

--- a/dynamodb/src/main/scala/zio/dynamodb/syntax.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/syntax.scala
@@ -13,8 +13,8 @@ object syntax {
       zio.flatMap {
         case Left(e @ DynamoDBError.ItemError.DecodingError(_)) => ZIO.fail(e)
         case Left(DynamoDBError.ItemError.ValueNotFound(_))     => ZIO.succeed(None)
-        case Right(a)                             => ZIO.succeed(Some(a))
+        case Right(a)                                           => ZIO.succeed(Some(a))
       }
   }
-  
+
 }

--- a/examples/src/main/scala/zio/dynamodb/examples/dynamodblocal/DynamoDBLocalMain.scala
+++ b/examples/src/main/scala/zio/dynamodb/examples/dynamodblocal/DynamoDBLocalMain.scala
@@ -13,6 +13,7 @@ import zio.dynamodb.DynamoDBExecutor
 import zio.dynamodb.DynamoDBQuery.get
 import zio.dynamodb.DynamoDBQuery.put
 import zio.dynamodb.ProjectionExpression
+import zio.dynamodb.syntax._
 import zio.schema.DeriveSchema
 import zio.schema.Schema
 

--- a/examples/src/main/scala/zio/dynamodb/examples/dynamodblocal/DynamoDBLocalMain.scala
+++ b/examples/src/main/scala/zio/dynamodb/examples/dynamodblocal/DynamoDBLocalMain.scala
@@ -66,9 +66,9 @@ object DynamoDBLocalMain extends ZIOAppDefault {
   val examplePerson = Person(1, "avi")
 
   private val program = for {
-    _      <- put("person", examplePerson).execute
-    person <- get("person")(Person.id.partitionKey === 1).execute
-    _      <- zio.Console.printLine(s"hello $person")
+    _           <- put("person", examplePerson).execute
+    maybePerson <- get("person")(Person.id.partitionKey === 1).execute.maybeFound
+    _           <- zio.Console.printLine(s"hello $maybePerson")
   } yield ()
 
   override def run =


### PR DESCRIPTION
closes https://github.com/zio/zio-dynamodb/issues/377

The `get` method in the High Level API has a precise `Out` type of `Either[ItemError, From]` where `ItemError` can be `ValueNotFound` or `DecodingError`. When we always expect a get to be successful we can simplify the client code using the ZIO `absolve` method eg `DynamoDBQuery.get("table")(Person.id.partitionKey === 1).execute.absolve` to get rid of the Either which pushes all `ItemError`'s to the error channel.

However a common use case is when we try and `get` an item and it may not exist. For this use case the `maybeFound` extension method will simplify the client code by pushing only the `DecodingError` case to the error channel and returning a None for the  `ValueNotFound` case eg `DynamoDBQuery.get("table")(Person.id.partitionKey === 1).execute.maybeFound` 