### PR TITLE
relax IsPrimaryKey proof to include optional fields

### DIFF
--- a/dynamodb/src/it/scala/zio/dynamodb/TypeSafeScanAndQuerySpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/TypeSafeScanAndQuerySpec.scala
@@ -244,31 +244,31 @@ object TypeSafeScanAndQuerySpec extends DynamoDBLocalSpec {
     }
   )
 
-  final case class PersonGsi(id: String, accountId: String, surname: String, age: Int)
+  final case class PersonGsi(id: String, accountId: Option[String], surname: String, age: Int)
   object PersonGsi {
-    implicit val schema: Schema.CaseClass4[String, String, String, Int, PersonGsi] =
+    implicit val schema: Schema.CaseClass4[String, Option[String], String, Int, PersonGsi] =
       DeriveSchema.gen[PersonGsi]
-    val (id, accountId, surname, age)                                              = ProjectionExpression.accessors[PersonGsi]
+    val (id, accountId, surname, age)                                                      = ProjectionExpression.accessors[PersonGsi]
   }
 
   val gsiSuite =
     suite("Global Secondary Index suite")(
       test("query with global secondary index") {
         withIdAndAccountIdGsiTable { personTable =>
-          val person1 = PersonGsi("1", "account1", "Smith", 21)
-          val person2 = PersonGsi("2", "account1", "Jane", 42)
-          val person3 = PersonGsi("3", "account2", "Tarlochan", 42)
+          val person1 = PersonGsi("1", Option("account1"), "Smith", 21)
+          val person2 = PersonGsi("2", Option("account1"), "Jane", 42)
+          val person3 = PersonGsi("3", Option("account2"), "Tarlochan", 42)
           for {
             _         <- put(personTable, person1).execute
             _         <- put(personTable, person2).execute
             _         <- put(personTable, person3).execute
             stream    <- queryAll[PersonGsi](personTable)
-                           .whereKey(PersonGsi.accountId.partitionKey === "account1")
+                           .whereKey(PersonGsi.accountId.partitionKey === Option("account1"))
                            .indexName("accountId")
                            .execute
             xs        <- stream.runCollect
             t         <- querySome[PersonGsi](personTable, 3)
-                           .whereKey(PersonGsi.accountId.partitionKey === "account1")
+                           .whereKey(PersonGsi.accountId.partitionKey === Option("account1"))
                            .indexName("accountId")
                            .execute
             (xs2, lek) = t

--- a/dynamodb/src/main/scala/zio/dynamodb/proofs/IsPrimaryKey.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/proofs/IsPrimaryKey.scala
@@ -1,9 +1,10 @@
 package zio.dynamodb.proofs
 
 import scala.annotation.implicitNotFound
-import zio.dynamodb.KeyConditionExpr
 
-@implicitNotFound("DynamoDB does not support primary key type ${A} - allowed types are: String, Number, Binary")
+@implicitNotFound(
+  "DynamoDB does not support primary key type ${A} - allowed types are: String, Number, Binary and Options of those types"
+)
 sealed trait IsPrimaryKey[-A]
 
 object IsPrimaryKey {
@@ -15,9 +16,17 @@ object IsPrimaryKey {
   implicit val floatIsPrimaryKey: IsPrimaryKey[Float]           = new IsPrimaryKey[Float] {}
   implicit val doubleIsPrimaryKey: IsPrimaryKey[Double]         = new IsPrimaryKey[Double] {}
   implicit val bigDecimalIsPrimaryKey: IsPrimaryKey[BigDecimal] = new IsPrimaryKey[BigDecimal] {}
-
   implicit val binaryIsPrimaryKey: IsPrimaryKey[Iterable[Byte]] = new IsPrimaryKey[Iterable[Byte]] {}
 
-  implicit val sortKeyNotUsed: IsPrimaryKey[KeyConditionExpr.SortKeyNotUsed] =
-    new IsPrimaryKey[KeyConditionExpr.SortKeyNotUsed] {}
+  implicit val stringIsPrimaryKeyOpt: IsPrimaryKey[Option[String]]         = new IsPrimaryKey[Option[String]] {}
+  implicit val shortIsPrimaryKeyOpt: IsPrimaryKey[Option[Short]]           = new IsPrimaryKey[Option[Short]] {}
+  implicit val intIsPrimaryKeyOpt: IsPrimaryKey[Option[Int]]               = new IsPrimaryKey[Option[Int]] {}
+  implicit val longIsPrimaryKeyOpt: IsPrimaryKey[Option[Long]]             = new IsPrimaryKey[Option[Long]] {}
+  implicit val floatIsPrimaryKeyOpt: IsPrimaryKey[Option[Float]]           = new IsPrimaryKey[Option[Float]] {}
+  implicit val doubleIsPrimaryKeyOpt: IsPrimaryKey[Option[Double]]         = new IsPrimaryKey[Option[Double]] {}
+  implicit val bigDecimalIsPrimaryKeyOpt: IsPrimaryKey[Option[BigDecimal]] =
+    new IsPrimaryKey[Option[BigDecimal]] {}
+  implicit val binaryIsPrimaryKeyOpt: IsPrimaryKey[Option[Iterable[Byte]]] =
+    new IsPrimaryKey[Option[Iterable[Byte]]] {}
+
 }

--- a/dynamodb/src/main/scala/zio/dynamodb/proofs/IsPrimaryKey.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/proofs/IsPrimaryKey.scala
@@ -3,7 +3,7 @@ package zio.dynamodb.proofs
 import scala.annotation.implicitNotFound
 
 @implicitNotFound(
-  "DynamoDB does not support primary key type ${A} - allowed types are: String, Number, Binary and Options of those types"
+  "DynamoDB does not support primary key type ${A} - allowed types are: String, Number, Binary or an Option of those types"
 )
 sealed trait IsPrimaryKey[-A]
 


### PR DESCRIPTION
closes https://github.com/zio/zio-dynamodb/issues/404

I investigated tracking the different types of keys ie default partition key, local secondary and global secondary but this lead to an exponential explosion in complexity.