### PR TITLE
Add a typed ProjectionExpression constructor

### DIFF
--- a/dynamodb/src/main/scala/zio/dynamodb/ProjectionExpression.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/ProjectionExpression.scala
@@ -808,8 +808,11 @@ object ProjectionExpression extends ProjectionExpressionLowPriorityImplicits0 {
    * @see [[parse]]
    */
   def $(s: String): ProjectionExpression[Any, Unknown] =
+    $$(s)
+
+  def $$[From, To](s: String): ProjectionExpression[From, To] =
     parse(s) match {
-      case Right(a)  => a.unsafeFrom[Any].unsafeTo[Unknown]
+      case Right(a)  => a.unsafeFrom[From].unsafeTo[To]
       case Left(msg) => throw new IllegalStateException(msg)
     }
 

--- a/examples/src/main/scala/zio/dynamodb/examples/KeyConditionExprExample.scala
+++ b/examples/src/main/scala/zio/dynamodb/examples/KeyConditionExprExample.scala
@@ -11,8 +11,9 @@ object KeyConditionExprExample extends App {
 
   import zio.dynamodb.KeyConditionExpr._
   import zio.dynamodb.KeyConditionExpr.SortKeyEquals
-  import zio.dynamodb.ProjectionExpression.$
+  import zio.dynamodb.ProjectionExpression.{ $, $$ }
 
+  // Unsafe low-level API
   val x6 =
     $("foo.bar").partitionKey === 1 && $("foo.baz").sortKey === "y"
   val x7 = $("foo.bar").partitionKey === 1 && $("foo.baz").sortKey > 1
@@ -21,6 +22,14 @@ object KeyConditionExprExample extends App {
   val x9 =
     $("foo.bar").partitionKey === 1 && $("foo.baz").sortKey.beginsWith(1L)
 
+  // More type-safe low-level API
+  sealed trait UnderlyingModel
+  val peInt: ProjectionExpression[UnderlyingModel, Int]       = $$("foo.bar")
+  val peString: ProjectionExpression[UnderlyingModel, String] = $$("foo.baz")
+
+  val x6Int = peInt.partitionKey === 1 && peString.sortKey === "y"
+
+  // High-level API
   final case class Elephant(email: String, subject: String, age: Int)
   object Elephant {
     implicit val schema: Schema.CaseClass3[String, String, Int, Elephant] = DeriveSchema.gen[Elephant]


### PR DESCRIPTION
This PR adds an extra ProjectionExpression constructor with a type parameter.  

Let me know what you think about it! I know that it's a low-level API and we probably can't encourage users using it, but it can be really useful sometimes to hide some dirt under the table.

