### PR TITLE
some batching optimisation

### DIFF
--- a/docs/reference/auto-batching-and-parallelisation.md
+++ b/docs/reference/auto-batching-and-parallelisation.md
@@ -26,6 +26,7 @@ So the rules are as follows:
 - A query only qualifies for auto-batching  if it passes the following criteria: 
   - The query is a `PutItem` or `DeleteItem` operation (`put` and `deleteFrom` in the High Level API)
     - The query does not have a condition expression
+    - The query does not have a `ReturnValues` specified (default is `ReturnValues.None` which is OK)
   - The query is a `GetItem` operation (`get` in the High Level API)
     - The query's `projections` list contains the primary key - this is required to match the response data to the request. Note all fields are included by default so this is only a concern if you explicitly specify the projection expression.  
 - If a query does not qualify for auto-batching it will be parallelised automatically

--- a/docs/reference/auto-batching-and-parallelisation.md
+++ b/docs/reference/auto-batching-and-parallelisation.md
@@ -26,7 +26,7 @@ So the rules are as follows:
 - A query only qualifies for auto-batching  if it passes the following criteria: 
   - The query is a `PutItem` or `DeleteItem` operation (`put` and `deleteFrom` in the High Level API)
     - The query does not have a condition expression
-    - The query does not have a `ReturnValues` specified (default is `ReturnValues.None` which is OK)
+    - The query has `ReturnValues.None` specified (which is the default) - any other return value will invalidate batched execution.
   - The query is a `GetItem` operation (`get` in the High Level API)
     - The query's `projections` list contains the primary key - this is required to match the response data to the request. Note all fields are included by default so this is only a concern if you explicitly specify the projection expression.  
 - If a query does not qualify for auto-batching it will be parallelised automatically

--- a/dynamodb/src/it/scala/zio/dynamodb/Foo.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/Foo.scala
@@ -1,0 +1,9 @@
+package zio.dynamodb
+
+import zio.ZIO
+
+object Foo {
+  val list = List(ZIO.unit, ZIO.unit, ZIO.unit)
+
+  ZIO.foreach(list)(identity)
+}

--- a/dynamodb/src/it/scala/zio/dynamodb/Foo.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/Foo.scala
@@ -1,9 +1,0 @@
-package zio.dynamodb
-
-import zio.ZIO
-
-object Foo {
-  val list = List(ZIO.unit, ZIO.unit, ZIO.unit)
-
-  ZIO.foreach(list)(identity)
-}

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -1115,21 +1115,28 @@ object DynamoDBQuery {
       hasNoProjections || matchedPrimaryKeys.filter(_ == true).size == pk.map.size
     }
 
-    val isSingleQuery = constructors.size == 1 // single queries are not batched
+    val isSingleGetQuery   = constructors.count {
+      case _: GetItem => true
+      case _          => false
+    } == 1 // single GetItem queries are not batched
+    val isSingleWriteQuery = constructors.count {
+      case _: Write[_, _] => true
+      case _              => false
+    } == 1 // single PutItem/DeleteItem queries are not batched
 
     val (indexedNonBatched, indexedGets, indexedWrites) =
       constructors.zipWithIndex.foldLeft[(Chunk[IndexedConstructor], Chunk[IndexedGetItem], Chunk[IndexedWriteItem])](
         (Chunk.empty, Chunk.empty, Chunk.empty)
       ) {
         case ((nonBatched, gets, writes), (get @ GetItem(_, pk, pes, _, _, _), index))                              =>
-          if (isSingleQuery)
+          if (isSingleGetQuery)
             (nonBatched :+ (get -> index), gets, writes)
           else if (projectionsContainPrimaryKey(pes, pk))
             (nonBatched, gets :+ (get -> index), writes)
           else
             (nonBatched :+ (get       -> index), gets, writes)
         case ((nonBatched, gets, writes), (put @ PutItem(_, _, conditionExpression, _, _, returnValues, _), index)) =>
-          if (isSingleQuery)
+          if (isSingleWriteQuery)
             (nonBatched :+ (put -> index), gets, writes)
           else
             conditionExpression match {
@@ -1145,7 +1152,7 @@ object DynamoDBQuery {
               (nonBatched, gets, writes),
               (delete @ DeleteItem(_, _, conditionExpression, _, _, returnValues, _), index)
             ) =>
-          if (isSingleQuery)
+          if (isSingleWriteQuery)
             (nonBatched :+ (delete -> index), gets, writes)
           else
             conditionExpression match {

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -80,10 +80,12 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
       chunk   <- queries.takeAll
       _        = println(s"XXXXXXXX chunk: ${chunk.size}")
       result  <- ZIO.foreachPar(chunk)(identity).map { xs2 =>
-                   val xs: Chunk[(Any, Int)] = xs2.flatten
-                   val sorted: Chunk[Any]    = xs.sortBy(_._2).map(_._1)
-                   println(s"XXXXXXXX sorted2: $sorted")
-                   val out: Out              = assembler(sorted)
+                   val combined: Chunk[(Any, Int)]       = xs2.flatten
+                   val sortedWithValuePicked: Chunk[Any] = combined.sortBy {
+                     case (_, index) => index
+                   }.map { case (value, _) => value }
+                   println(s"XXXXXXXX sortedWithValuePicked: $sortedWithValuePicked")
+                   val out: Out                          = assembler(sortedWithValuePicked)
                    out
                  }
     } yield result

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -29,7 +29,7 @@ import zio.dynamodb.UpdateExpression.Action
 import zio.prelude.ForEachOps
 import zio.schema.Schema
 import zio.stream.Stream
-import zio.{ Chunk, Schedule, ZIO }
+import zio.{ Chunk, Queue, Schedule, ZIO }
 import scala.annotation.nowarn
 
 sealed trait DynamoDBQuery[-In, +Out] { self =>
@@ -72,95 +72,23 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
           ZIO.fail(resp.toErrorResponse)
       }
 
-    val x: ZIO[zio.dynamodb.DynamoDBExecutor, DynamoDBError, Out] = for {
-      queries <- zio.Queue.bounded[ZIO[DynamoDBExecutor, DynamoDBError, Chunk[(Any, Int)]]](3)
+    val result: ZIO[zio.dynamodb.DynamoDBExecutor, DynamoDBError, Out] = for {
+      queries <- Queue.bounded[ZIO[DynamoDBExecutor, DynamoDBError, Chunk[(Any, Int)]]](3)
       _       <- queries.offer(indexedNonBatchedResults).when(indexedConstructors.size > 0)
       _       <- queries.offer(indexedGetResults).when(batchGetIndexes.size > 0)
       _       <- queries.offer(indexedWriteResults).when(batchWriteIndexes.size > 0)
       chunk   <- queries.takeAll
-      _        = println(s"XXXXXXXX chunk: ${chunk.size}")
-      result  <- ZIO.foreachPar(chunk)(identity).map { xs2 =>
-                   val combined: Chunk[(Any, Int)]       = xs2.flatten
-                   val sortedWithValuePicked: Chunk[Any] = combined.sortBy {
+      result  <- ZIO.foreachPar(chunk)(identity).map { xs =>
+                   val combined: Chunk[(Any, Int)] = xs.flatten
+                   val sortedValues: Chunk[Any]    = combined.sortBy {
                      case (_, index) => index
                    }.map { case (value, _) => value }
-                   println(s"XXXXXXXX sortedWithValuePicked: $sortedWithValuePicked")
-                   val out: Out                          = assembler(sortedWithValuePicked)
+                   val out: Out                    = assembler(sortedValues)
                    out
                  }
     } yield result
 
-    val y =
-      (indexedNonBatchedResults zipPar indexedGetResults zipPar indexedWriteResults).map {
-        case (nonBatched, batchedGets, batchedWrites) =>
-          val combined: Chunk[(Any, Int)] = (nonBatched ++ batchedGets ++ batchedWrites)
-          val combinedSorted: Chunk[Any]  = combined.sortBy {
-            case (_, index) => index
-          }.map { case (value, _) => value }
-          println(s"XXXXXXXX nonBatched.size: ${nonBatched.size}")
-          println(s"XXXXXXXX combinedSorted.size: ${combinedSorted.size}")
-          val out: Out                    = assembler(combinedSorted)
-          out
-      }
-
-    // def sortByIndexAndTakeValue(chunk: Chunk[(Any, Int)])                 =
-    //   chunk.sortBy {
-    //     case (_, index) => index
-    //   }.map { case (value, _) => value }
-
-    // def sortByIndexAndTakeValue2(t: (Chunk[(Any, Int)], Chunk[(Any, Int)])): Chunk[Any] = {
-    //   val chunk = t._1 ++ t._2
-    //   chunk.sortBy {
-    //     case (_, index) => index
-    //   }.map { case (value, _) => value }
-    // }
-
-    def assemble2(t: (Chunk[(Any, Int)], Chunk[(Any, Int)])): Out = {
-      val chunk: Chunk[(Any, Int)]                     = t._1 ++ t._2
-      val chunkSortedByIndexAndValuePicked: Chunk[Any] = chunk.sortBy {
-        case (_, index) => index
-      }.map { case (value, _) => value }
-      assembler(chunkSortedByIndexAndValuePicked)
-    }
-    def assemble3(t: (Chunk[(Any, Int)], Chunk[(Any, Int)], Chunk[(Any, Int)])): Out = {
-      val chunk: Chunk[(Any, Int)]                     = t._1 ++ t._2 ++ t._3
-      val chunkSortedByIndexAndValuePicked: Chunk[Any] = chunk.sortBy {
-        case (_, index) => index
-      }.map { case (value, _) => value }
-      assembler(chunkSortedByIndexAndValuePicked)
-    }
-    val z = (indexedConstructors.nonEmpty, batchGetIndexes.nonEmpty, batchWriteIndexes.nonEmpty) match {
-      case (false, false, false) =>
-        println(s"YYYYYYYYY 1")
-        //.asInstanceOf[ZIO[DynamoDBExecutor, DynamoDBError, Out]] // TODO: Avi this should never happen
-        throw new RuntimeException("This should never happen")
-      case (false, false, true)  =>
-        println(s"YYYYYYYYY 2")
-        indexedWriteResults.map(xs =>
-          assembler(xs.map(_._1))
-        ) //.asInstanceOf[ZIO[DynamoDBExecutor, DynamoDBError, Out]]
-      case (false, true, false)  =>
-        println(s"YYYYYYYYY 3")
-        indexedGetResults.map(xs => assembler(xs.map(_._1))) // TODO: Avi - replicate this for arity 1
-      case (true, false, false)  =>
-        println(s"YYYYYYYYY 4")
-        indexedNonBatchedResults.map(xs => assembler(xs.map(_._1)))
-      case (true, true, false)   =>
-        println(s"YYYYYYYYY 5")
-        (indexedNonBatchedResults zipPar indexedGetResults).map(assemble2)
-      case (true, false, true)   =>
-        println(s"YYYYYYYYY 6")
-        (indexedNonBatchedResults zipPar indexedWriteResults).map(assemble2)
-      case (true, true, true)    =>
-        println(s"YYYYYYYYY 7")
-        (indexedNonBatchedResults zipPar indexedGetResults zipPar indexedWriteResults).map(assemble3)
-      case (false, true, true)   =>
-        println(s"YYYYYYYYY 8")
-        (indexedGetResults zipPar indexedWriteResults).map(assemble2)
-    }
-    println(s"$x $y $z")
-
-    x
+    result
   }
 
   final def indexName(indexName: String): DynamoDBQuery[In, Out] =
@@ -1196,11 +1124,10 @@ object DynamoDBQuery {
         case ((nonBatched, gets, writes), (get @ GetItem(_, pk, pes, _, _, _), index))                              =>
           if (isSingleQuery)
             (nonBatched :+ (get -> index), gets, writes)
-          else if (projectionsContainPrimaryKey(pes, pk)) {
-            println(s"XXXXXXXXXX BATCHING ${(get -> index)}")
+          else if (projectionsContainPrimaryKey(pes, pk))
             (nonBatched, gets :+ (get -> index), writes)
-          } else
-            (nonBatched :+ (get -> index), gets, writes)
+          else
+            (nonBatched :+ (get       -> index), gets, writes)
         case ((nonBatched, gets, writes), (put @ PutItem(_, _, conditionExpression, _, _, returnValues, _), index)) =>
           if (isSingleQuery)
             (nonBatched :+ (put -> index), gets, writes)
@@ -1243,10 +1170,6 @@ object DynamoDBQuery {
       .foldLeft[(BatchWriteItem, Chunk[Int])]((BatchWriteItem(), Chunk.empty)) {
         case ((batchWriteItem, indexes), (writeItem, index)) => (batchWriteItem + writeItem, indexes :+ index)
       }
-
-    println(s"XXXXXXXXXXX indexedNonBatched $indexedNonBatched")
-    println(s"XXXXXXXXXXX indexedBatchGetItem $indexedBatchGetItem")
-    println(s"XXXXXXXXXXX indexedBatchWrite $indexedBatchWrite")
 
     (indexedNonBatched, indexedBatchGetItem, indexedBatchWrite)
   }

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -67,13 +67,23 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
           ZIO.fail(resp.toErrorResponse)
       }
 
-    (indexedNonBatchedResults zipPar indexedGetResults zipPar indexedWriteResults).map {
-      case (nonBatched, batchedGets, batchedWrites) =>
-        val combined = (nonBatched ++ batchedGets ++ batchedWrites).sortBy {
-          case (_, index) => index
-        }.map { case (value, _) => value }
-        assembler(combined)
-    }
+    // TODO: Avi optomise lleling
+    if (batchWriteIndexes.size == 0)
+      (indexedGetResults).map {
+        case (batchedGets) =>
+          val combined = (batchedGets).sortBy {
+            case (_, index) => index
+          }.map { case (value, _) => value }
+          assembler(combined)
+      }
+    else
+      (indexedNonBatchedResults zipPar indexedGetResults zipPar indexedWriteResults).map {
+        case (nonBatched, batchedGets, batchedWrites) =>
+          val combined = (nonBatched ++ batchedGets ++ batchedWrites).sortBy {
+            case (_, index) => index
+          }.map { case (value, _) => value }
+          assembler(combined)
+      }
 
   }
 
@@ -1110,10 +1120,11 @@ object DynamoDBQuery {
         case ((nonBatched, gets, writes), (get @ GetItem(_, pk, pes, _, _, _), index))                              =>
           if (isSingleQuery)
             (nonBatched :+ (get -> index), gets, writes)
-          else if (projectionsContainPrimaryKey(pes, pk))
+          else if (projectionsContainPrimaryKey(pes, pk)) {
+            println(s"XXXXXXXXXX BATCHING ${(get -> index)}")
             (nonBatched, gets :+ (get -> index), writes)
-          else
-            (nonBatched :+ (get       -> index), gets, writes)
+          } else
+            (nonBatched :+ (get -> index), gets, writes)
         case ((nonBatched, gets, writes), (put @ PutItem(_, _, conditionExpression, _, _, returnValues, _), index)) =>
           if (isSingleQuery)
             (nonBatched :+ (put -> index), gets, writes)
@@ -1156,6 +1167,10 @@ object DynamoDBQuery {
       .foldLeft[(BatchWriteItem, Chunk[Int])]((BatchWriteItem(), Chunk.empty)) {
         case ((batchWriteItem, indexes), (writeItem, index)) => (batchWriteItem + writeItem, indexes :+ index)
       }
+
+    println(s"XXXXXXXXXXX indexedNonBatched $indexedNonBatched")
+    println(s"XXXXXXXXXXX indexedBatchGetItem $indexedBatchGetItem")
+    println(s"XXXXXXXXXXX indexedBatchWrite $indexedBatchWrite")
 
     (indexedNonBatched, indexedBatchGetItem, indexedBatchWrite)
   }

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -74,7 +74,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
 
     val x: ZIO[zio.dynamodb.DynamoDBExecutor, DynamoDBError, Out] = for {
       queries <- zio.Queue.bounded[ZIO[DynamoDBExecutor, DynamoDBError, Chunk[(Any, Int)]]](3)
-      _       <- queries.offer(indexedNonBatchedResults).when(batchWriteIndexes.size > 0)
+      _       <- queries.offer(indexedNonBatchedResults).when(indexedConstructors.size > 0)
       _       <- queries.offer(indexedGetResults).when(batchGetIndexes.size > 0)
       _       <- queries.offer(indexedWriteResults).when(batchWriteIndexes.size > 0)
       chunk   <- queries.takeAll
@@ -158,7 +158,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
     }
     println(s"$x $y $z")
 
-    z
+    x
   }
 
   final def indexName(indexName: String): DynamoDBQuery[In, Out] =

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -78,7 +78,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
       _       <- queries.offer(indexedGetResults).when(batchGetIndexes.size > 0)
       _       <- queries.offer(indexedWriteResults).when(batchWriteIndexes.size > 0)
       chunk   <- queries.takeAll
-      result  <- ZIO.foreachPar(chunk)(identity).map { xs =>
+      result  <- ZIO.collectAllPar(chunk).map { xs =>
                    val combined: Chunk[(Any, Int)] = xs.flatten
                    val sortedValues: Chunk[Any]    = combined.sortBy {
                      case (_, index) => index

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -41,17 +41,22 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
   final def <*>[In1 <: In, B](that: DynamoDBQuery[In1, B]): DynamoDBQuery[In1, (Out, B)] = self zip that
 
   def execute: ZIO[DynamoDBExecutor, DynamoDBError, Out] = {
-    val (constructors, assembler)                                                                   = parallelize(self)
-    val (indexedConstructors, (batchGetItem, batchGetIndexes), (batchWriteItem, batchWriteIndexes)) =
-      batched(constructors)
+    val (constructors: Chunk[DynamoDBQuery.Constructor[In, Any]], assembler: Function1[Chunk[Any], Out]) = parallelize(
+      self
+    )
+    val (
+      indexedConstructors: Chunk[(DynamoDBQuery.Constructor[In, Any], Int)],
+      (batchGetItem: BatchGetItem, batchGetIndexes: Chunk[Int]),
+      (batchWriteItem: BatchWriteItem, batchWriteIndexes: Chunk[Int])
+    )                                                                                                    = batched(constructors)
 
-    val indexedNonBatchedResults =
+    val indexedNonBatchedResults: ZIO[DynamoDBExecutor, DynamoDBError, Chunk[(Any, Int)]] =
       ZIO.foreachPar(indexedConstructors) {
         case (constructor, index) =>
           ddbExecute(constructor).map(result => (result, index))
       }
 
-    val indexedGetResults =
+    val indexedGetResults: ZIO[DynamoDBExecutor, DynamoDBError, Chunk[(Option[AttrMap], Int)]] =
       ddbExecute(batchGetItem).flatMap {
         case resp @ BatchGetItem.Response(_, unprocessedKeys) if unprocessedKeys.size == 0 =>
           ZIO.succeed(batchGetItem.toGetItemResponses(resp) zip batchGetIndexes)
@@ -59,7 +64,7 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
           ZIO.fail(resp.toErrorResponse)
       }
 
-    val indexedWriteResults =
+    val indexedWriteResults: ZIO[DynamoDBExecutor, DynamoDBError, Chunk[(Option[Any], Int)]] =
       ddbExecute(batchWriteItem).flatMap {
         case BatchWriteItem.Response(unprocessedItems) if unprocessedItems.size == 0 =>
           ZIO.succeed(batchWriteItem.addList.map(_ => None) zip batchWriteIndexes)
@@ -67,24 +72,93 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
           ZIO.fail(resp.toErrorResponse)
       }
 
-    // TODO: Avi optomise lleling
-    if (batchWriteIndexes.size == 0)
-      (indexedGetResults).map {
-        case (batchedGets) =>
-          val combined = (batchedGets).sortBy {
-            case (_, index) => index
-          }.map { case (value, _) => value }
-          assembler(combined)
-      }
-    else
+    val x: ZIO[zio.dynamodb.DynamoDBExecutor, DynamoDBError, Out] = for {
+      queries <- zio.Queue.bounded[ZIO[DynamoDBExecutor, DynamoDBError, Chunk[(Any, Int)]]](3)
+      _       <- queries.offer(indexedNonBatchedResults).when(batchWriteIndexes.size > 0)
+      _       <- queries.offer(indexedGetResults).when(batchGetIndexes.size > 0)
+      _       <- queries.offer(indexedWriteResults).when(batchWriteIndexes.size > 0)
+      chunk   <- queries.takeAll
+      _        = println(s"XXXXXXXX chunk: ${chunk.size}")
+      result  <- ZIO.foreachPar(chunk)(identity).map { xs2 =>
+                   val xs: Chunk[(Any, Int)] = xs2.flatten
+                   val sorted: Chunk[Any]    = xs.sortBy(_._2).map(_._1)
+                   println(s"XXXXXXXX sorted2: $sorted")
+                   val out: Out              = assembler(sorted)
+                   out
+                 }
+    } yield result
+
+    val y =
       (indexedNonBatchedResults zipPar indexedGetResults zipPar indexedWriteResults).map {
         case (nonBatched, batchedGets, batchedWrites) =>
-          val combined = (nonBatched ++ batchedGets ++ batchedWrites).sortBy {
+          val combined: Chunk[(Any, Int)] = (nonBatched ++ batchedGets ++ batchedWrites)
+          val combinedSorted: Chunk[Any]  = combined.sortBy {
             case (_, index) => index
           }.map { case (value, _) => value }
-          assembler(combined)
+          println(s"XXXXXXXX nonBatched.size: ${nonBatched.size}")
+          println(s"XXXXXXXX combinedSorted.size: ${combinedSorted.size}")
+          val out: Out                    = assembler(combinedSorted)
+          out
       }
 
+    // def sortByIndexAndTakeValue(chunk: Chunk[(Any, Int)])                 =
+    //   chunk.sortBy {
+    //     case (_, index) => index
+    //   }.map { case (value, _) => value }
+
+    // def sortByIndexAndTakeValue2(t: (Chunk[(Any, Int)], Chunk[(Any, Int)])): Chunk[Any] = {
+    //   val chunk = t._1 ++ t._2
+    //   chunk.sortBy {
+    //     case (_, index) => index
+    //   }.map { case (value, _) => value }
+    // }
+
+    def assemble2(t: (Chunk[(Any, Int)], Chunk[(Any, Int)])): Out = {
+      val chunk: Chunk[(Any, Int)]                     = t._1 ++ t._2
+      val chunkSortedByIndexAndValuePicked: Chunk[Any] = chunk.sortBy {
+        case (_, index) => index
+      }.map { case (value, _) => value }
+      assembler(chunkSortedByIndexAndValuePicked)
+    }
+    def assemble3(t: (Chunk[(Any, Int)], Chunk[(Any, Int)], Chunk[(Any, Int)])): Out = {
+      val chunk: Chunk[(Any, Int)]                     = t._1 ++ t._2 ++ t._3
+      val chunkSortedByIndexAndValuePicked: Chunk[Any] = chunk.sortBy {
+        case (_, index) => index
+      }.map { case (value, _) => value }
+      assembler(chunkSortedByIndexAndValuePicked)
+    }
+    val z = (indexedConstructors.nonEmpty, batchGetIndexes.nonEmpty, batchWriteIndexes.nonEmpty) match {
+      case (false, false, false) =>
+        println(s"YYYYYYYYY 1")
+        //.asInstanceOf[ZIO[DynamoDBExecutor, DynamoDBError, Out]] // TODO: Avi this should never happen
+        throw new RuntimeException("This should never happen")
+      case (false, false, true)  =>
+        println(s"YYYYYYYYY 2")
+        indexedWriteResults.map(xs =>
+          assembler(xs.map(_._1))
+        ) //.asInstanceOf[ZIO[DynamoDBExecutor, DynamoDBError, Out]]
+      case (false, true, false)  =>
+        println(s"YYYYYYYYY 3")
+        indexedGetResults.map(xs => assembler(xs.map(_._1))) // TODO: Avi - replicate this for arity 1
+      case (true, false, false)  =>
+        println(s"YYYYYYYYY 4")
+        indexedNonBatchedResults.map(xs => assembler(xs.map(_._1)))
+      case (true, true, false)   =>
+        println(s"YYYYYYYYY 5")
+        (indexedNonBatchedResults zipPar indexedGetResults).map(assemble2)
+      case (true, false, true)   =>
+        println(s"YYYYYYYYY 6")
+        (indexedNonBatchedResults zipPar indexedWriteResults).map(assemble2)
+      case (true, true, true)    =>
+        println(s"YYYYYYYYY 7")
+        (indexedNonBatchedResults zipPar indexedGetResults zipPar indexedWriteResults).map(assemble3)
+      case (false, true, true)   =>
+        println(s"YYYYYYYYY 8")
+        (indexedGetResults zipPar indexedWriteResults).map(assemble2)
+    }
+    println(s"$x $y $z")
+
+    z
   }
 
   final def indexName(indexName: String): DynamoDBQuery[In, Out] =

--- a/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
@@ -190,8 +190,8 @@ object AutoBatchedFailureSpec extends ZIOSpecDefault with DynamoDBFixtures {
     )
 
   private val batchGetSuite =
-    suite("retry batch gets")(
-      suite("experiment")(test("should die when BatchGetItem returns AWS error") {
+    suite("batch gets")(
+      suite("with defects")(test("should die when BatchGetItem returns AWS error") {
         val autoBatched =
           getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)
         for {

--- a/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
@@ -19,6 +19,7 @@ import zio.{ Schedule, ULayer }
 import scala.collection.immutable.{ Map => ScalaMap }
 import zio.test.TestAspect
 import zio.test.Assertion
+import zio.test.assertTrue
 import zio.Chunk
 
 import zio.schema.DeriveSchema
@@ -195,7 +196,7 @@ object AutoBatchedFailureSpec extends ZIOSpecDefault with DynamoDBFixtures {
         for {
           exit <- autoBatched.execute.exit
           _     = println(s"XXXXXXXXX exit: $exit")
-        } yield zio.test.assert(exit)(succeeds(anything))
+        } yield assertTrue(true)
       }).provideLayer(errorReturnMockBatchGet >>> DynamoDBExecutor.live) @@ TestAspect.withLiveClock,
       suite("successful batch gets")(test("should retry when there are unprocessed keys") {
         val autoBatched = getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)

--- a/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
@@ -18,8 +18,9 @@ import zio.{ Schedule, ULayer }
 
 import scala.collection.immutable.{ Map => ScalaMap }
 import zio.test.TestAspect
+import zio.test.Assertion.isSubtype
 import zio.test.Assertion
-import zio.test.assertTrue
+import zio.test.assert
 import zio.Chunk
 
 import zio.schema.DeriveSchema
@@ -185,18 +186,17 @@ object AutoBatchedFailureSpec extends ZIOSpecDefault with DynamoDBFixtures {
   val errorReturnMockBatchGet: ULayer[DynamoDb] = DynamoDbMock
     .BatchGetItem(
       equalTo(getRequestItemOneAndTwo()),
-      failure(zio.aws.core.AwsError.fromThrowable(new Exception("BOOOOOOM!")))
+      failure(zio.aws.core.AwsError.fromThrowable(new IllegalStateException("BOOOOOOM!")))
     )
 
   private val batchGetSuite =
     suite("retry batch gets")(
-      suite("experiment")(test("should fail when BatchGetItem returns AWS error") {
+      suite("experiment")(test("should die when BatchGetItem returns AWS error") {
         val autoBatched =
           getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)
         for {
           exit <- autoBatched.execute.exit
-          _     = println(s"XXXXXXXXX exit: $exit")
-        } yield assertTrue(true)
+        } yield assert(exit)(dies(isSubtype[IllegalStateException](hasMessage(containsString("BOOOOOOM!")))))
       }).provideLayer(errorReturnMockBatchGet >>> DynamoDBExecutor.live) @@ TestAspect.withLiveClock,
       suite("successful batch gets")(test("should retry when there are unprocessed keys") {
         val autoBatched = getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)

--- a/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
@@ -11,6 +11,7 @@ import zio.aws.dynamodb.{ DynamoDb, DynamoDbMock }
 import zio.dynamodb.DynamoDBError.BatchError
 import zio.dynamodb.DynamoDBQuery._
 import zio.mock.Expectation.value
+import zio.mock.Expectation.failure
 import zio.test.Assertion.{ fails, _ }
 import zio.test.{ assertZIO, ZIOSpecDefault }
 import zio.{ Schedule, ULayer }
@@ -180,8 +181,22 @@ object AutoBatchedFailureSpec extends ZIOSpecDefault with DynamoDBFixtures {
       )
     )
 
+  val errorReturnMockBatchGet: ULayer[DynamoDb] = DynamoDbMock
+    .BatchGetItem(
+      equalTo(getRequestItemOneAndTwo()),
+      failure(zio.aws.core.AwsError.fromThrowable(new Exception("BOOOOOOM!")))
+    )
+
   private val batchGetSuite =
     suite("retry batch gets")(
+      suite("experiment")(test("should fail when BatchGetItem returns AWS error") {
+        val autoBatched =
+          getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)
+        for {
+          exit <- autoBatched.execute.exit
+          _     = println(s"XXXXXXXXX exit: $exit")
+        } yield zio.test.assert(exit)(succeeds(anything))
+      }).provideLayer(errorReturnMockBatchGet >>> DynamoDBExecutor.live) @@ TestAspect.withLiveClock,
       suite("successful batch gets")(test("should retry when there are unprocessed keys") {
         val autoBatched = getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)
         assertZIO(autoBatched.execute.exit)(succeeds(anything))

--- a/dynamodb/src/test/scala/zio/dynamodb/BatchedSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/BatchedSpec.scala
@@ -1,0 +1,117 @@
+package zio.dynamodb
+
+import zio.test.ZIOSpecDefault
+import zio.test.assertTrue
+import zio.dynamodb.DynamoDBQuery.{ deleteItem, getItem, putItem }
+import zio.Chunk
+import zio.dynamodb.DynamoDBQuery.Constructor
+import ProjectionExpression.$
+
+object BatchedSpec extends ZIOSpecDefault {
+  val item1 = Item("id" -> "1")
+  val item2 = Item("id" -> "2")
+  val spec  = suite("Batched suite")(
+    test("Single GetItem queries do not get batched") {
+      val get1                                           = getItem("table1", item1)
+      val constructors: Chunk[Constructor[AttrMap, Any]] =
+        Chunk(get1).asInstanceOf[Chunk[Constructor[Any, Option[AttrMap]]]]
+      val (
+        nonBatched: Chunk[(Constructor[AttrMap, Any], Int)],
+        batchGetItem: (DynamoDBQuery.BatchGetItem, Chunk[Int]),
+        batchWriteItem: (DynamoDBQuery.BatchWriteItem, Chunk[Int])
+      )                                                  = DynamoDBQuery.batched(constructors)
+
+      assertTrue(
+        nonBatched.size == 1,
+        batchGetItem._1.requestItems.isEmpty,
+        batchWriteItem._1.requestItems.isEmpty
+      )
+    },
+    test("Single PutItem queries do not get batched") {
+      val put1                                           = putItem("table1", item1)
+      val constructors: Chunk[Constructor[AttrMap, Any]] =
+        Chunk(put1).asInstanceOf[Chunk[Constructor[Any, Option[AttrMap]]]]
+      val (
+        nonBatched: Chunk[(Constructor[AttrMap, Any], Int)],
+        batchGetItem: (DynamoDBQuery.BatchGetItem, Chunk[Int]),
+        batchWriteItem: (DynamoDBQuery.BatchWriteItem, Chunk[Int])
+      )                                                  = DynamoDBQuery.batched(constructors)
+
+      assertTrue(
+        nonBatched.size == 1,
+        batchGetItem._1.requestItems.isEmpty,
+        batchWriteItem._1.requestItems.isEmpty
+      )
+    },
+    test("Single DeleteItem queries do not get batched") {
+      val delete1                                        = deleteItem("table1", item1)
+      val constructors: Chunk[Constructor[AttrMap, Any]] =
+        Chunk(delete1).asInstanceOf[Chunk[Constructor[Any, Option[AttrMap]]]]
+      val (
+        nonBatched: Chunk[(Constructor[AttrMap, Any], Int)],
+        batchGetItem: (DynamoDBQuery.BatchGetItem, Chunk[Int]),
+        batchWriteItem: (DynamoDBQuery.BatchWriteItem, Chunk[Int])
+      )                                                  = DynamoDBQuery.batched(constructors)
+
+      assertTrue(
+        nonBatched.size == 1,
+        batchGetItem._1.requestItems.isEmpty,
+        batchWriteItem._1.requestItems.isEmpty
+      )
+    },
+    test("Multiple GetItems should be batched") {
+      val get1                                           = getItem("table1", item1)
+      val get2                                           = getItem("table1", item2)
+      val constructors: Chunk[Constructor[AttrMap, Any]] =
+        Chunk(get1, get2).asInstanceOf[Chunk[Constructor[Any, Option[AttrMap]]]]
+      val (
+        nonBatched: Chunk[(Constructor[AttrMap, Any], Int)],
+        batchGetItem: (DynamoDBQuery.BatchGetItem, Chunk[Int]),
+        batchWriteItem: (DynamoDBQuery.BatchWriteItem, Chunk[Int])
+      )                                                  = DynamoDBQuery.batched(constructors)
+
+      assertTrue(
+        nonBatched.isEmpty,
+        batchGetItem._1.requestItems.size == 1,
+        batchGetItem._1.requestItems.get(TableName("table1")).get.keysSet.size == 2,
+        batchWriteItem._1.requestItems.isEmpty
+      )
+    },
+    test("A PutItem and DeleteItem should be batched") {
+      val put1                                           = putItem("table1", item1)
+      val delete1                                        = deleteItem("table1", item2)
+      val constructors: Chunk[Constructor[AttrMap, Any]] =
+        Chunk(put1, delete1).asInstanceOf[Chunk[Constructor[Any, Option[AttrMap]]]]
+      val (
+        nonBatched: Chunk[(Constructor[AttrMap, Any], Int)],
+        batchGetItem: (DynamoDBQuery.BatchGetItem, Chunk[Int]),
+        batchWriteItem: (DynamoDBQuery.BatchWriteItem, Chunk[Int])
+      )                                                  = DynamoDBQuery.batched(constructors)
+
+      assertTrue(
+        nonBatched.isEmpty,
+        batchGetItem._1.requestItems.isEmpty,
+        batchWriteItem._1.requestItems.size == 1,
+        batchWriteItem._1.requestItems.get(TableName("table1")).get.size == 2
+      )
+    },
+    test("Put/Delete Items with conditions should not be batched") {
+      val put1                                           = putItem("table1", item1).where($("table.id") === "1")
+      val delete1                                        = deleteItem("table1", item2).where($("table.id") === "2")
+      val constructors: Chunk[Constructor[AttrMap, Any]] =
+        Chunk(put1, delete1).asInstanceOf[Chunk[Constructor[Any, Option[AttrMap]]]]
+      val (
+        nonBatched: Chunk[(Constructor[AttrMap, Any], Int)],
+        batchGetItem: (DynamoDBQuery.BatchGetItem, Chunk[Int]),
+        batchWriteItem: (DynamoDBQuery.BatchWriteItem, Chunk[Int])
+      )                                                  = DynamoDBQuery.batched(constructors)
+
+      assertTrue(
+        nonBatched.size == 2,
+        batchGetItem._1.requestItems.isEmpty,
+        batchWriteItem._1.requestItems.isEmpty
+      )
+    }
+  )
+
+}

--- a/dynamodb/src/test/scala/zio/dynamodb/BatchedSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/BatchedSpec.scala
@@ -59,6 +59,40 @@ object BatchedSpec extends ZIOSpecDefault {
         batchWriteItem._1.requestItems.isEmpty
       )
     },
+    test("A GetItem and a DeleteItem do not get batched") {
+      val get1                                           = getItem("table1", item1)
+      val delete1                                        = deleteItem("table1", item2)
+      val constructors: Chunk[Constructor[AttrMap, Any]] =
+        Chunk(get1, delete1).asInstanceOf[Chunk[Constructor[Any, Option[AttrMap]]]]
+      val (
+        nonBatched: Chunk[(Constructor[AttrMap, Any], Int)],
+        batchGetItem: (DynamoDBQuery.BatchGetItem, Chunk[Int]),
+        batchWriteItem: (DynamoDBQuery.BatchWriteItem, Chunk[Int])
+      )                                                  = DynamoDBQuery.batched(constructors)
+
+      assertTrue(
+        nonBatched.size == 2,
+        batchGetItem._1.requestItems.size == 0,
+        batchWriteItem._1.requestItems.size == 0
+      )
+    },
+    test("A GetItem and a PutItem do not get batched") {
+      val get1                                           = getItem("table1", item1)
+      val put1                                           = putItem("table1", item2)
+      val constructors: Chunk[Constructor[AttrMap, Any]] =
+        Chunk(get1, put1).asInstanceOf[Chunk[Constructor[Any, Option[AttrMap]]]]
+      val (
+        nonBatched: Chunk[(Constructor[AttrMap, Any], Int)],
+        batchGetItem: (DynamoDBQuery.BatchGetItem, Chunk[Int]),
+        batchWriteItem: (DynamoDBQuery.BatchWriteItem, Chunk[Int])
+      )                                                  = DynamoDBQuery.batched(constructors)
+
+      assertTrue(
+        nonBatched.size == 2,
+        batchGetItem._1.requestItems.size == 0,
+        batchWriteItem._1.requestItems.size == 0
+      )
+    },
     test("Multiple GetItems should be batched") {
       val get1                                           = getItem("table1", item1)
       val get2                                           = getItem("table1", item2)

--- a/dynamodb/src/test/scala/zio/dynamodb/BatchedSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/BatchedSpec.scala
@@ -145,6 +145,23 @@ object BatchedSpec extends ZIOSpecDefault {
         batchGetItem._1.requestItems.isEmpty,
         batchWriteItem._1.requestItems.isEmpty
       )
+    },
+    test("Put/Delete Items with return values other than ReturnValues.None should not be batched") {
+      val put1                                           = putItem("table1", item1).returns(ReturnValues.AllNew)
+      val delete1                                        = deleteItem("table1", item2).returns(ReturnValues.AllOld)
+      val constructors: Chunk[Constructor[AttrMap, Any]] =
+        Chunk(put1, delete1).asInstanceOf[Chunk[Constructor[Any, Option[AttrMap]]]]
+      val (
+        nonBatched: Chunk[(Constructor[AttrMap, Any], Int)],
+        batchGetItem: (DynamoDBQuery.BatchGetItem, Chunk[Int]),
+        batchWriteItem: (DynamoDBQuery.BatchWriteItem, Chunk[Int])
+      )                                                  = DynamoDBQuery.batched(constructors)
+
+      assertTrue(
+        nonBatched.size == 2,
+        batchGetItem._1.requestItems.isEmpty,
+        batchWriteItem._1.requestItems.isEmpty
+      )
     }
   )
 

--- a/dynamodb/src/test/scala/zio/dynamodb/BatchingDSLSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/BatchingDSLSpec.scala
@@ -199,18 +199,6 @@ object BatchingDSLSpec extends ZIOSpecDefault with DynamoDBFixtures {
   private def assertQueryNotBatched(queries: List[DynamoDBQuery[_, _]]) =
     assertTrue(queries.size == 1) && assertTrue(isNonBatched(queries.head))
 
-  // private def isEmptyBatchWrite(q: DynamoDBQuery[_, _]): Boolean =
-  //   q match {
-  //     case BatchWriteItem(items, _, _, _, _) => items.isEmpty
-  //     case _                                 => false
-  //   }
-
-  // private def isEmptyBatchGet(q: DynamoDBQuery[_, _]): Boolean =
-  //   q match {
-  //     case BatchGetItem(items, _, _, _) => items.isEmpty
-  //     case _                            => false
-  //   }
-
   private def isNonBatched(q: DynamoDBQuery[_, _]): Boolean =
     q match {
       case BatchGetItem(_, _, _, _)      => false

--- a/dynamodb/src/test/scala/zio/dynamodb/BatchingDSLSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/BatchingDSLSpec.scala
@@ -197,21 +197,25 @@ object BatchingDSLSpec extends ZIOSpecDefault with DynamoDBFixtures {
   )
 
   private def assertQueryNotBatched(queries: List[DynamoDBQuery[_, _]]) =
-    assertTrue(queries.size == 3) && assertTrue(
-      queries.find(isEmptyBatchWrite).isDefined
-    ) && assertTrue(
-      queries.find(isEmptyBatchGet).isDefined
-    )
+    assertTrue(queries.size == 1) && assertTrue(isNonBatched(queries.head))
 
-  private def isEmptyBatchWrite(q: DynamoDBQuery[_, _]): Boolean =
+  // private def isEmptyBatchWrite(q: DynamoDBQuery[_, _]): Boolean =
+  //   q match {
+  //     case BatchWriteItem(items, _, _, _, _) => items.isEmpty
+  //     case _                                 => false
+  //   }
+
+  // private def isEmptyBatchGet(q: DynamoDBQuery[_, _]): Boolean =
+  //   q match {
+  //     case BatchGetItem(items, _, _, _) => items.isEmpty
+  //     case _                            => false
+  //   }
+
+  private def isNonBatched(q: DynamoDBQuery[_, _]): Boolean =
     q match {
-      case BatchWriteItem(items, _, _, _, _) => items.isEmpty
-      case _                                 => false
+      case BatchGetItem(_, _, _, _)      => false
+      case BatchWriteItem(_, _, _, _, _) => false
+      case _                             => true
     }
 
-  private def isEmptyBatchGet(q: DynamoDBQuery[_, _]): Boolean =
-    q match {
-      case BatchGetItem(items, _, _, _) => items.isEmpty
-      case _                            => false
-    }
 }


### PR DESCRIPTION
Fixes old batching algorithm which always resulted in at least 2 fibers being created, even when no parallelisation was required due to static `zipPar`'s. New algorithm removes superfluous fibre creation. 

Also there is a fix to an edge case where combined single GetItem and a single Put/DeleteItem were getting executed as single item batched queries - these are now executed as parallel single queries.