### PR TITLE
Generic Record Decoder empty document and optional fields handling fix

### DIFF
--- a/dynamodb/src/it/scala/zio/dynamodb/TypeSafeApiCrudSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/TypeSafeApiCrudSpec.scala
@@ -14,8 +14,6 @@ import zio.ZIO
 import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException
 import zio.Scope
 
-import scala.annotation.nowarn
-
 object TypeSafeApiCrudSpec extends DynamoDBLocalSpec {
 
   case class PersonMetaData(address: Option[String], postcode: Option[String])
@@ -64,8 +62,7 @@ object TypeSafeApiCrudSpec extends DynamoDBLocalSpec {
  )
   // format: on
   object Big {
-    @nowarn
-    implicit val schema = DeriveSchema.gen[Big]
+    implicit val schema: Schema[Big] = DeriveSchema.gen[Big]
 
     val id: ProjectionExpression[Big, String] = ProjectionExpression.$$("id")
   }

--- a/dynamodb/src/it/scala/zio/dynamodb/TypeSafeApiCrudSpec.scala
+++ b/dynamodb/src/it/scala/zio/dynamodb/TypeSafeApiCrudSpec.scala
@@ -14,6 +14,8 @@ import zio.ZIO
 import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException
 import zio.Scope
 
+import scala.annotation.nowarn
+
 object TypeSafeApiCrudSpec extends DynamoDBLocalSpec {
 
   case class PersonMetaData(address: Option[String], postcode: Option[String])
@@ -52,6 +54,20 @@ object TypeSafeApiCrudSpec extends DynamoDBLocalSpec {
       : Schema.CaseClass5[String, String, List[Address], Map[String, Address], Set[String], PersonWithCollections] =
       DeriveSchema.gen[PersonWithCollections]
     val (id, surname, addressList, addressMap, addressSet)                                                         = ProjectionExpression.accessors[PersonWithCollections]
+  }
+
+  // format: off
+  case class Big(
+    id: String, f0: String, f1: String, f2: String, f3: String, f4: String, f5: String, f6: String, f7: String, f8: String, f9: String,
+    f10: String, f11: String, f12: String, f13: String, f14: String, f15: String, f16: String, f17: String, f18: String, f19: String,
+    f20: String, f21: String, f22: String, f23: String, f24: String, f25: String, f26: String, f27: String, f28: String, f29: Option[String], f30: Option[String]
+ )
+  // format: on
+  object Big {
+    @nowarn
+    implicit val schema = DeriveSchema.gen[Big]
+
+    val id: ProjectionExpression[Big, String] = ProjectionExpression.$$("id")
   }
 
   final case class PersonWithEither(id: String, address: Either[String, List[String]])
@@ -93,6 +109,20 @@ object TypeSafeApiCrudSpec extends DynamoDBLocalSpec {
             _ <- put(tableName, person).execute
             p <- get(tableName)(Person.id.partitionKey === "1").execute.absolve
           } yield assertTrue(p == person)
+        }
+      },
+      test("big case class simple round trip") {
+        withSingleIdKeyTable { tableName =>
+          // format: off
+          val big = Big(
+            "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+            "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", Some("31"), Some("32")
+          )
+          // format: on
+          for {
+            _ <- put(tableName, big).execute
+            b <- get(tableName)(Big.id.partitionKey === "1").execute.absolve
+          } yield assertTrue(b == big)
         }
       },
       test("and get using maybeFound extension method") {

--- a/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
@@ -172,7 +172,10 @@ private[dynamodb] object Codec {
             val value              = valuesMap(key)
             val enc                = encoder[a](schema)
             val av: AttributeValue = enc(value.asInstanceOf[a])
-            AttributeValue.Map(avMap.value + (AttributeValue.String(key) -> av))
+            av match {
+              case AttributeValue.Null => avMap
+              case _                   => AttributeValue.Map(avMap.value + (AttributeValue.String(key) -> av))
+            }
         }
       }
 
@@ -579,8 +582,7 @@ private[dynamodb] object Codec {
                       case Right(value) => Right(key -> value)
                       case Left(s)      => Left(s)
                     }
-                  case None =>
-                    Right(key -> None)
+                  case None     => Right(key -> None)
                 }
             }
               .map(ls => ListMap.newBuilder.++=(ls).result())

--- a/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
@@ -572,11 +572,15 @@ private[dynamodb] object Codec {
           case AttributeValue.Map(map) =>
             structure.toChunk.forEach {
               case Schema.Field(key, schema: Schema[a], _, _, _, _) =>
-                val av  = map(AttributeValue.String(key))
-                val dec = decoder(schema)
-                dec(av) match {
-                  case Right(value) => Right(key -> value)
-                  case Left(s)      => Left(s)
+                map.get(AttributeValue.String(key)) match {
+                  case Some(av) =>
+                    val dec = decoder(schema)
+                    dec(av) match {
+                      case Right(value) => Right(key -> value)
+                      case Left(s)      => Left(s)
+                    }
+                  case None     => // empty document case
+                    Left(DecodingError(s"Expected AttributeValue.Map $key not found."))
                 }
             }
               .map(ls => ListMap.newBuilder.++=(ls).result())

--- a/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
@@ -579,8 +579,8 @@ private[dynamodb] object Codec {
                       case Right(value) => Right(key -> value)
                       case Left(s)      => Left(s)
                     }
-                  case None     => // empty document case
-                    Left(DecodingError(s"Expected AttributeValue.Map $key not found."))
+                  case None =>
+                    Right(key -> None)
                 }
             }
               .map(ls => ListMap.newBuilder.++=(ls).result())

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/CodecRoundTripSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/CodecRoundTripSpec.scala
@@ -390,6 +390,10 @@ object CodecRoundTripSpec extends ZIOSpecDefault with CodecTestFixtures {
       assertTrue(
         itemBig.map.values.filter(_ == AttributeValue.Null) ==
           itemCase21.map.values.filter(_ == AttributeValue.Null)
+      ) &&
+      assertTrue(
+        !itemBig.map.values.exists(_ == AttributeValue.Null) &&
+          !itemCase21.map.values.exists(_ == AttributeValue.Null)
       )
     }
   )

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/CodecRoundTripSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/CodecRoundTripSpec.scala
@@ -1,6 +1,6 @@
 package zio.dynamodb.codec
 
-import zio.dynamodb.Codec
+import zio.dynamodb.{ AttributeValue, Codec, DynamoDBQuery }
 import zio.schema.{ DeriveSchema, Schema, StandardType }
 import zio.test.Assertion.{ equalTo, isRight }
 import zio.test._
@@ -9,6 +9,7 @@ import zio.{ Chunk, ZIO }
 import scala.collection.immutable.ListMap
 import zio.test.{ Gen, Sized, ZIOSpecDefault }
 import zio.schema.TypeId
+
 import java.time.ZoneOffset
 
 object CodecRoundTripSpec extends ZIOSpecDefault with CodecTestFixtures {
@@ -23,7 +24,8 @@ object CodecRoundTripSpec extends ZIOSpecDefault with CodecTestFixtures {
       sequenceSuite,
       enumerationSuite,
       transformSuite,
-      anySchemaSuite
+      anySchemaSuite,
+      bigSchemaSuite
     )
 
   private val eitherSuite = suite("either suite")(
@@ -343,6 +345,52 @@ object CodecRoundTripSpec extends ZIOSpecDefault with CodecTestFixtures {
         case (schema, value) =>
           assertEncodesThenDecodes(schema.asInstanceOf[Schema[Any]], value)
       }
+    }
+  )
+
+  private val bigSchemaSuite = suite("big schema")(
+    test("encodes CaseClass TwentyOne, decodes to Big") {
+      // format: off
+      val case21 = Case21(
+        "id", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10",
+        "f11", "f12", "f13", "f14", "f15", "f16", "f17", None, Some("f19")
+      )
+
+      val big = Big(
+        "id", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10",
+        "f11", "f12", "f13", "f14", "f15", "f16", "f17", None, Some("f19"),
+        None, None, None, None, None, None, None, None, None, None, None
+      )
+      // format: on
+
+      val item       = DynamoDBQuery.toItem(case21)
+      val bigDecoded = DynamoDBQuery.fromItem[Big](item)
+
+      assert(bigDecoded)(isRight(equalTo(big)))
+    },
+    test("encodes Big, decodes to CaseClass TwentyOne, preserving document level backwards compatibility") {
+      // format: off
+      val case21 = Case21(
+        "id", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10",
+        "f11", "f12", "f13", "f14", "f15", "f16", "f17", None, Some("f19")
+      )
+
+      val big = Big(
+        "id", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10",
+        "f11", "f12", "f13", "f14", "f15", "f16", "f17", None, Some("f19"),
+        None, None, None, None, None, None, None, None, None, None, None
+      )
+      // format: on
+
+      val itemBig       = DynamoDBQuery.toItem(big)
+      val itemCase21    = DynamoDBQuery.toItem(case21)
+      val case21Decoded = DynamoDBQuery.fromItem[Case21](itemBig)
+
+      assert(case21Decoded)(isRight(equalTo(case21))) &&
+      assertTrue(
+        itemBig.map.values.filter(_ == AttributeValue.Null) ==
+          itemCase21.map.values.filter(_ == AttributeValue.Null)
+      )
     }
   )
 

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/models.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/models.scala
@@ -165,3 +165,53 @@ object WithNoDiscriminatorError {
   implicit val schema: Schema.CaseClass1[NoDiscriminatorEnumError, WithNoDiscriminatorError] =
     DeriveSchema.gen[WithNoDiscriminatorError]
 }
+
+// format: off
+case class Case21(
+  id: String, f0: String, f1: String, f2: String, f3: String, f4: String, f5: String, f6: String, f7: String, f8: String, f9: String,
+  f10: String, f11: String, f12: String, f13: String, f14: String, f15: String, f16: String, f17: String, f18: Option[String], f19: Option[String]
+)
+// format: on
+object Case21 {
+  implicit val schema: Schema.CaseClass21[
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    Option[String],
+    Option[String],
+    Case21
+  ] =
+    DeriveSchema.gen[Case21]
+
+  val id: ProjectionExpression[Case21, String] = ProjectionExpression.$$("id")
+}
+
+// format: off
+case class Big(
+  id: String, f0: String, f1: String, f2: String, f3: String, f4: String, f5: String, f6: String, f7: String, f8: String, f9: String,
+  f10: String, f11: String, f12: String, f13: String, f14: String, f15: String, f16: String, f17: String, f18: Option[String], f19: Option[String],
+  f20: Option[String], f21: Option[String], f22: Option[String], f23: Option[String], f24: Option[String], f25: Option[String], f26: Option[String], f27: Option[String],
+  f28: Option[String], f29: Option[String], f30: Option[String],
+)
+// format: on
+object Big {
+  implicit val schema: Schema[Big] = DeriveSchema.gen[Big]
+
+  val id: ProjectionExpression[Big, String] = ProjectionExpression.$$("id")
+}


### PR DESCRIPTION
Generic Record Decoder throws `NoSuchElementException("key not found: " + key)` on an empty document / missing key (i.e. dropped during the encoding), which might be a legit case on an empty Map.

One of another challenges was to ensure it is similar to the case classes encoding.