### PR TITLE
Added support for dynamic schema

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -336,9 +336,10 @@ lazy val zioDynamodbJson =
       resolvers ++= Resolver.sonatypeOssRepos("releases"),
       fork := true,
       libraryDependencies ++= Seq(
-        "dev.zio" %% "zio-test"     % zioVersion % "test",
-        "dev.zio" %% "zio-test-sbt" % zioVersion % "test",
-        "dev.zio" %% "zio-json"     % "0.7.44"
+        "dev.zio" %% "zio-test"        % zioVersion       % "test",
+        "dev.zio" %% "zio-test-sbt"    % zioVersion       % "test",
+        "dev.zio" %% "zio-json"        % "0.7.44",
+        "dev.zio" %% "zio-schema-json" % zioSchemaVersion % "test"
       ),
       testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
     )

--- a/dynamodb-json/src/test/scala/zio/dynamodb/json/JsonAstSerdeSpec.scala
+++ b/dynamodb-json/src/test/scala/zio/dynamodb/json/JsonAstSerdeSpec.scala
@@ -1,0 +1,324 @@
+package zio.dynamodb.json
+
+import zio.Scope
+import zio.dynamodb.{ AttributeValue, Codec }
+import zio.json.ast.Json
+import zio.schema.codec.json.schemaJson
+import zio.test.Assertion._
+import zio.test.{ assert, Spec, TestEnvironment, ZIOSpecDefault }
+
+object JsonAstSerdeSpec extends ZIOSpecDefault {
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("JsonAstSerdeSpec")(
+      encoderSuite,
+      decoderSuite,
+      roundTripSuite
+    )
+
+  val encoderSuite = suite("JSON AST to AttributeValue encoder suite")(
+    test("encode Json.Str") {
+      val json    = Json.Str("hello")
+      val encoded = Codec.encoder(schemaJson)(json)
+
+      assert(encoded)(equalTo(AttributeValue.String("hello")))
+    },
+    test("encode Json.Num") {
+      val json    = Json.Num(42.5)
+      val encoded = Codec.encoder(schemaJson)(json)
+
+      assert(encoded)(equalTo(AttributeValue.Number(BigDecimal(42.5))))
+    },
+    test("encode Json.Bool") {
+      val json    = Json.Bool(true)
+      val encoded = Codec.encoder(schemaJson)(json)
+
+      assert(encoded)(equalTo(AttributeValue.Bool(true)))
+    },
+    test("encode Json.Null") {
+      val json    = Json.Null
+      val encoded = Codec.encoder(schemaJson)(json)
+
+      assert(encoded)(equalTo(AttributeValue.Null))
+    },
+    test("encode Json.Obj") {
+      val json    = Json.Obj(
+        "name"     -> Json.Str("John"),
+        "age"      -> Json.Num(30),
+        "active"   -> Json.Bool(true),
+        "metadata" -> Json.Null
+      )
+      val encoded = Codec.encoder(schemaJson)(json)
+
+      val expected = AttributeValue.Map.empty +
+        ("name"     -> AttributeValue.String("John")) +
+        ("age"      -> AttributeValue.Number(BigDecimal(30))) +
+        ("active"   -> AttributeValue.Bool(true)) +
+        ("metadata" -> AttributeValue.Null)
+
+      assert(encoded)(equalTo(expected))
+    },
+    test("encode Json.Arr") {
+      val json    = Json.Arr(
+        Json.Str("first"),
+        Json.Num(42),
+        Json.Bool(false),
+        Json.Null
+      )
+      val encoded = Codec.encoder(schemaJson)(json)
+
+      val expected = AttributeValue.List(
+        List(
+          AttributeValue.String("first"),
+          AttributeValue.Number(BigDecimal(42)),
+          AttributeValue.Bool(false),
+          AttributeValue.Null
+        )
+      )
+
+      assert(encoded)(equalTo(expected))
+    },
+    test("encode nested Json.Obj") {
+      val json    = Json.Obj(
+        "user"  -> Json.Obj(
+          "name" -> Json.Str("Alice"),
+          "age"  -> Json.Num(25)
+        ),
+        "items" -> Json.Arr(
+          Json.Str("item1"),
+          Json.Str("item2")
+        )
+      )
+      val encoded = Codec.encoder(schemaJson)(json)
+
+      val expected = AttributeValue.Map.empty +
+        ("user"   -> (AttributeValue.Map.empty +
+          ("name" -> AttributeValue.String("Alice")) +
+          ("age"  -> AttributeValue.Number(BigDecimal(25))))) +
+        ("items"  -> AttributeValue.List(
+          List(
+            AttributeValue.String("item1"),
+            AttributeValue.String("item2")
+          )
+        ))
+
+      assert(encoded)(equalTo(expected))
+    },
+    test("encode empty Json.Obj") {
+      val json    = Json.Obj()
+      val encoded = Codec.encoder(schemaJson)(json)
+
+      assert(encoded)(equalTo(AttributeValue.Map.empty))
+    },
+    test("encode empty Json.Arr") {
+      val json    = Json.Arr()
+      val encoded = Codec.encoder(schemaJson)(json)
+
+      assert(encoded)(equalTo(AttributeValue.List(List.empty)))
+    }
+  )
+
+  val decoderSuite = suite("AttributeValue to JSON AST decoder suite")(
+    test("decode AttributeValue.String to Json") {
+      val av      = AttributeValue.String("hello")
+      val decoded = Codec.decoder(schemaJson)(av)
+
+      assert(decoded)(isRight(equalTo(Json.Str("hello"))))
+    },
+    test("decode AttributeValue.Number to Json") {
+      val av      = AttributeValue.Number(BigDecimal(42))
+      val decoded = Codec.decoder(schemaJson)(av)
+
+      assert(decoded)(isRight(equalTo(Json.Num(42))))
+    },
+    test("decode AttributeValue.Bool to Json") {
+      val av      = AttributeValue.Bool(true)
+      val decoded = Codec.decoder(schemaJson)(av)
+
+      assert(decoded)(isRight(equalTo(Json.Bool(true))))
+    },
+    test("decode AttributeValue.Null to Json") {
+      val av      = AttributeValue.Null
+      val decoded = Codec.decoder(schemaJson)(av)
+
+      assert(decoded)(isRight(equalTo(Json.Null)))
+    },
+    test("decode AttributeValue.Map to Json") {
+      val av = AttributeValue.Map.empty +
+        ("name"   -> AttributeValue.String("John")) +
+        ("age"    -> AttributeValue.Number(BigDecimal(30))) +
+        ("active" -> AttributeValue.Bool(true))
+      val decoded = Codec.decoder(schemaJson)(av)
+
+      val expected = Json.Obj(
+        "name"   -> Json.Str("John"),
+        "age"    -> Json.Num(30),
+        "active" -> Json.Bool(true)
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decode AttributeValue.List to Json") {
+      val av      = AttributeValue.List(
+        List(
+          AttributeValue.String("first"),
+          AttributeValue.String("second"),
+          AttributeValue.Number(BigDecimal(42))
+        )
+      )
+      val decoded = Codec.decoder(schemaJson)(av)
+
+      val expected = Json.Arr(
+        Json.Str("first"),
+        Json.Str("second"),
+        Json.Num(42)
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decode nested AttributeValue.Map to Json") {
+      val av = AttributeValue.Map.empty +
+        ("user"   -> (AttributeValue.Map.empty +
+          ("name" -> AttributeValue.String("Alice")) +
+          ("age"  -> AttributeValue.Number(BigDecimal(25))))) +
+        ("items"  -> AttributeValue.List(
+          List(
+            AttributeValue.String("item1"),
+            AttributeValue.String("item2")
+          )
+        ))
+
+      val decoded = Codec.decoder(schemaJson)(av)
+
+      val expected = Json.Obj(
+        "user"  -> Json.Obj(
+          "name" -> Json.Str("Alice"),
+          "age"  -> Json.Num(25)
+        ),
+        "items" -> Json.Arr(
+          Json.Str("item1"),
+          Json.Str("item2")
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decode empty AttributeValue.Map to Json") {
+      val av      = AttributeValue.Map.empty
+      val decoded = Codec.decoder(schemaJson)(av)
+
+      assert(decoded)(isRight(equalTo(Json.Obj())))
+    },
+    test("decode empty AttributeValue.List to Json") {
+      val av      = AttributeValue.List(List.empty)
+      val decoded = Codec.decoder(schemaJson)(av)
+
+      assert(decoded)(isRight(equalTo(Json.Arr())))
+    }
+  )
+
+  val roundTripSuite = suite("JSON AST round-trip tests")(
+    test("round-trip Json.Str") {
+      val original = Json.Str("test string")
+      val encoded  = Codec.encoder(schemaJson)(original)
+      val decoded  = Codec.decoder(schemaJson)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip Json.Bool") {
+      val original = Json.Bool(false)
+      val encoded  = Codec.encoder(schemaJson)(original)
+      val decoded  = Codec.decoder(schemaJson)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip Json.Null") {
+      val original = Json.Null
+      val encoded  = Codec.encoder(schemaJson)(original)
+      val decoded  = Codec.decoder(schemaJson)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip simple Json.Obj") {
+      val original = Json.Obj(
+        "name"   -> Json.Str("Bob"),
+        "active" -> Json.Bool(true)
+      )
+      val encoded  = Codec.encoder(schemaJson)(original)
+      val decoded  = Codec.decoder(schemaJson)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip Json.Arr") {
+      val original = Json.Arr(
+        Json.Str("apple"),
+        Json.Str("banana"),
+        Json.Bool(true)
+      )
+      val encoded  = Codec.encoder(schemaJson)(original)
+      val decoded  = Codec.decoder(schemaJson)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip complex nested Json") {
+      val original = Json.Obj(
+        "metadata" -> Json.Obj(
+          "version" -> Json.Str("1.0"),
+          "stable"  -> Json.Bool(true)
+        ),
+        "tags"     -> Json.Arr(
+          Json.Str("important"),
+          Json.Str("verified")
+        ),
+        "config"   -> Json.Obj(
+          "enabled"  -> Json.Bool(true),
+          "settings" -> Json.Obj(
+            "debug" -> Json.Bool(false)
+          )
+        )
+      )
+      val encoded  = Codec.encoder(schemaJson)(original)
+      val decoded  = Codec.decoder(schemaJson)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip with Json.Num") {
+      val original = Json.Obj(
+        "count" -> Json.Num(42),
+        "pi"    -> Json.Num(3.14159)
+      )
+      val encoded  = Codec.encoder(schemaJson)(original)
+      val decoded  = Codec.decoder(schemaJson)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip empty structures") {
+      val original = Json.Obj(
+        "empty_object" -> Json.Obj(),
+        "empty_array"  -> Json.Arr()
+      )
+      val encoded  = Codec.encoder(schemaJson)(original)
+      val decoded  = Codec.decoder(schemaJson)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip Json.Num as primitive") {
+      val original = Json.Num(123.456)
+      val encoded  = Codec.encoder(schemaJson)(original)
+      val decoded  = Codec.decoder(schemaJson)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip mixed Json types in array") {
+      val original = Json.Arr(
+        Json.Str("text"),
+        Json.Num(42),
+        Json.Bool(true),
+        Json.Null,
+        Json.Obj("key" -> Json.Str("value")),
+        Json.Arr(Json.Str("nested"))
+      )
+      val encoded  = Codec.encoder(schemaJson)(original)
+      val decoded  = Codec.decoder(schemaJson)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    }
+  )
+}

--- a/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
@@ -614,7 +614,7 @@ private[dynamodb] object Codec {
           case AttributeValue.Bool(value)      => Right(DynamicValue.Primitive(value, StandardType.BoolType))
           case AttributeValue.List(_)          =>
             sequenceDecoder[DynamicValue, DynamicValue](dynamicDecoder, DynamicValue.Sequence(_))(av)
-          case AttributeValue.Map(value)       =>
+          case AttributeValue.Map(_)           =>
             nativeMapDecoder(dynamicDecoder)(av).map((map) =>
               DynamicValue.Record(TypeId.parse("AttributeValue.Map"), ListMap(map.toList: _*))
             )

--- a/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
@@ -6,7 +6,7 @@ import zio.dynamodb.DynamoDBError.ItemError
 import zio.prelude.{ FlipOps, ForEachOps }
 import zio.schema.Schema.{ Optional, Primitive }
 import zio.schema.annotation.caseName
-import zio.schema.{ Fallback, FieldSet, Schema, StandardType }
+import zio.schema.{ DynamicValue, Fallback, FieldSet, Schema, StandardType, TypeId }
 import zio.Chunk
 
 import java.math.BigInteger
@@ -176,8 +176,47 @@ private[dynamodb] object Codec {
         }
       }
 
-    private def dynamicEncoder[A]: Encoder[A] =
-      encoder(Schema.dynamicValue).asInstanceOf[Encoder[A]]
+    private def dynamicEncoder: Encoder[DynamicValue] =
+      (dynamicValue: DynamicValue) =>
+        dynamicValue match {
+          case DynamicValue.Record(_, values)              =>
+            values.foldRight(AttributeValue.Map(ListMap.empty)) {
+              case ((key, dv), avMap) =>
+                AttributeValue.Map(avMap.value + (AttributeValue.String(key) -> dynamicEncoder(dv)))
+            }
+          case DynamicValue.Enumeration(_, _)              =>
+            throw new Exception("DynamicValue.Enumeration is not supported")
+          case DynamicValue.Sequence(values)               =>
+            AttributeValue.List(values.map(dynamicEncoder))
+          case DynamicValue.Dictionary(_)                  =>
+            throw new Exception("DynamicValue.Dictionary is not supported")
+          case DynamicValue.SetValue(values)               => encodeSetValues(values.map(dynamicEncoder))
+          case DynamicValue.Primitive(value, standardType) => primitiveEncoder(standardType)(value)
+          case DynamicValue.Singleton(_)                   => AttributeValue.Map(ListMap.empty)
+          case DynamicValue.SomeValue(value)               => dynamicEncoder(value)
+          case DynamicValue.NoneValue                      => AttributeValue.Null
+          case DynamicValue.Tuple(left, right)             =>
+            AttributeValue.List(Chunk(dynamicEncoder(left), dynamicEncoder(right)))
+          case DynamicValue.LeftValue(value)               =>
+            AttributeValue.Map(Map(AttributeValue.String("Left") -> dynamicEncoder(value)))
+          case DynamicValue.RightValue(value)              =>
+            AttributeValue.Map(Map(AttributeValue.String("Right") -> dynamicEncoder(value)))
+          case DynamicValue.BothValue(_, _)                => throw new Exception("DynamicValue.BothValue is not supported")
+          case DynamicValue.DynamicAst(_)                  => throw new Exception("DynamicValue.DynamicAst is not supported")
+          case DynamicValue.Error(_)                       => throw new Exception("DynamicValue.Error is not supported")
+        }
+
+    private def encodeSetValues(encodedValues: Set[AttributeValue]): AttributeValue =
+      encodedValues.headOption match {
+        case Some(_: AttributeValue.String) if encodedValues.forall(_.isInstanceOf[AttributeValue.String]) =>
+          AttributeValue.StringSet(encodedValues.map(_.asInstanceOf[AttributeValue.String].value))
+        case Some(_: AttributeValue.Number) if encodedValues.forall(_.isInstanceOf[AttributeValue.Number]) =>
+          AttributeValue.NumberSet(encodedValues.map(_.asInstanceOf[AttributeValue.Number].value))
+        case Some(_: AttributeValue.Binary) if encodedValues.forall(_.isInstanceOf[AttributeValue.Binary]) =>
+          AttributeValue.BinarySet(encodedValues.map(_.asInstanceOf[AttributeValue.Binary].value))
+        case _                                                                                             =>
+          AttributeValue.List(encodedValues.toList)
+      }
 
     private def caseClassEncoder0[Z]: Encoder[Z] = _ => AttributeValue.Null
 
@@ -563,8 +602,35 @@ private[dynamodb] object Codec {
     private[dynamodb] def caseClass0Decoder[Z](schema: Schema.CaseClass0[Z]): Decoder[Z] =
       _ => Right(schema.defaultConstruct())
 
-    private def dynamicDecoder[A]: Decoder[A] =
-      decoder(Schema.dynamicValue).asInstanceOf[Decoder[A]]
+    private def dynamicDecoder: Decoder[DynamicValue] =
+      (av: AttributeValue) =>
+        av match {
+          case AttributeValue.Binary(value)    =>
+            Right(DynamicValue.Primitive(value.toChunk, StandardType.BinaryType))
+          case AttributeValue.BinarySet(value) =>
+            Right(
+              DynamicValue.SetValue(value.map(bi => DynamicValue.Primitive(bi.toChunk, StandardType.BinaryType)).toSet)
+            )
+          case AttributeValue.Bool(value)      => Right(DynamicValue.Primitive(value, StandardType.BoolType))
+          case AttributeValue.List(_)          =>
+            sequenceDecoder[DynamicValue, DynamicValue](dynamicDecoder, DynamicValue.Sequence(_))(av)
+          case AttributeValue.Map(value)       =>
+            nativeMapDecoder(dynamicDecoder)(av).map((map) =>
+              DynamicValue.Record(TypeId.parse("AttributeValue.Map"), ListMap(map.toList: _*))
+            )
+          case AttributeValue.Number(value)    =>
+            Right(DynamicValue.Primitive(value.bigDecimal, StandardType.BigDecimalType))
+          case AttributeValue.NumberSet(value) =>
+            Right(
+              DynamicValue.SetValue(
+                value.map(n => DynamicValue.Primitive(n.bigDecimal, StandardType.BigDecimalType)).toSet
+              )
+            )
+          case AttributeValue.Null             => Right(DynamicValue.NoneValue)
+          case AttributeValue.String(value)    => Right(DynamicValue.Primitive(value, StandardType.StringType))
+          case AttributeValue.StringSet(value) =>
+            Right(DynamicValue.SetValue(value.map(s => DynamicValue.Primitive(s, StandardType.StringType)).toSet))
+        }
 
     private def genericRecordDecoder(structure: FieldSet): Decoder[Any] =
       (av: AttributeValue) =>

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/DynamicCodecSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/DynamicCodecSpec.scala
@@ -1,0 +1,575 @@
+package zio.dynamodb.codec
+
+import zio.dynamodb._
+import zio.test.Assertion._
+import zio.test._
+import zio.schema.{ DynamicValue, StandardType, TypeId }
+import zio.Chunk
+import scala.collection.immutable.ListMap
+
+object DynamicCodecSpec extends ZIOSpecDefault with CodecTestFixtures {
+
+  override def spec: Spec[Environment, Any] =
+    suite("DynamicCodec Suite")(
+      dynamicEncoderSuite,
+      dynamicDecoderSuite,
+      dynamicRoundTripSuite
+    )
+
+  private val dynamicEncoderSuite = suite("DynamicEncoder Suite")(
+    test("encodes DynamicValue.Primitive with String") {
+      val dynamicValue = DynamicValue.Primitive("test", StandardType.StringType)
+      val encoded      = Codec.encoder(zio.schema.Schema.dynamicValue)(dynamicValue)
+
+      assert(encoded)(equalTo(AttributeValue.String("test")))
+    },
+    test("encodes DynamicValue.Primitive with Int") {
+      val dynamicValue = DynamicValue.Primitive(42, StandardType.IntType)
+      val encoded      = Codec.encoder(zio.schema.Schema.dynamicValue)(dynamicValue)
+
+      assert(encoded)(equalTo(AttributeValue.Number(BigDecimal(42))))
+    },
+    test("encodes DynamicValue.Primitive with Boolean") {
+      val dynamicValue = DynamicValue.Primitive(true, StandardType.BoolType)
+      val encoded      = Codec.encoder(zio.schema.Schema.dynamicValue)(dynamicValue)
+
+      assert(encoded)(equalTo(AttributeValue.Bool(true)))
+    },
+    test("encodes DynamicValue.Primitive with BigDecimal") {
+      val bigDecimal   = BigDecimal("123.45").bigDecimal
+      val dynamicValue = DynamicValue.Primitive(bigDecimal, StandardType.BigDecimalType)
+      val encoded      = Codec.encoder(zio.schema.Schema.dynamicValue)(dynamicValue)
+
+      assert(encoded)(equalTo(AttributeValue.Number(BigDecimal(bigDecimal))))
+    },
+    test("encodes DynamicValue.Primitive with Binary") {
+      val binary       = Chunk.fromArray("test".getBytes)
+      val dynamicValue = DynamicValue.Primitive(binary, StandardType.BinaryType)
+      val encoded      = Codec.encoder(zio.schema.Schema.dynamicValue)(dynamicValue)
+
+      assert(encoded)(equalTo(AttributeValue.Binary(binary)))
+    },
+    test("encodes DynamicValue.Record") {
+      val record  = DynamicValue.Record(
+        TypeId.Structural,
+        ListMap(
+          "name" -> DynamicValue.Primitive("John", StandardType.StringType),
+          "age"  -> DynamicValue.Primitive(30, StandardType.IntType)
+        )
+      )
+      val encoded = Codec.encoder(zio.schema.Schema.dynamicValue)(record)
+
+      val expected = AttributeValue.Map(
+        Map(
+          AttributeValue.String("name") -> AttributeValue.String("John"),
+          AttributeValue.String("age")  -> AttributeValue.Number(BigDecimal(30))
+        )
+      )
+      assert(encoded)(equalTo(expected))
+    },
+    test("encodes DynamicValue.Sequence") {
+      val sequence = DynamicValue.Sequence(
+        Chunk(
+          DynamicValue.Primitive("first", StandardType.StringType),
+          DynamicValue.Primitive("second", StandardType.StringType)
+        )
+      )
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(sequence)
+
+      val expected = AttributeValue.List(
+        List(
+          AttributeValue.String("first"),
+          AttributeValue.String("second")
+        )
+      )
+      assert(encoded)(equalTo(expected))
+    },
+    test("encodes DynamicValue.SetValue with String elements as StringSet") {
+      val setValue = DynamicValue.SetValue(
+        Set(
+          DynamicValue.Primitive("first", StandardType.StringType),
+          DynamicValue.Primitive("second", StandardType.StringType)
+        )
+      )
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(setValue)
+
+      assert(encoded)(equalTo(AttributeValue.StringSet(Set("first", "second"))))
+    },
+    test("encodes DynamicValue.SetValue with Number elements as NumberSet") {
+      val setValue = DynamicValue.SetValue(
+        Set(
+          DynamicValue.Primitive(BigDecimal(1).bigDecimal, StandardType.BigDecimalType),
+          DynamicValue.Primitive(BigDecimal(2).bigDecimal, StandardType.BigDecimalType)
+        )
+      )
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(setValue)
+
+      assert(encoded)(equalTo(AttributeValue.NumberSet(Set(BigDecimal(1), BigDecimal(2)))))
+    },
+    test("encodes DynamicValue.SetValue with Binary elements as BinarySet") {
+      val binary1  = Chunk.fromArray("test1".getBytes)
+      val binary2  = Chunk.fromArray("test2".getBytes)
+      val setValue = DynamicValue.SetValue(
+        Set(
+          DynamicValue.Primitive(binary1, StandardType.BinaryType),
+          DynamicValue.Primitive(binary2, StandardType.BinaryType)
+        )
+      )
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(setValue)
+
+      assert(encoded)(equalTo(AttributeValue.BinarySet(Set(binary1, binary2))))
+    },
+    test("encodes DynamicValue.SetValue with mixed elements as List") {
+      val setValue = DynamicValue.SetValue(
+        Set(
+          DynamicValue.Primitive("string", StandardType.StringType),
+          DynamicValue.Primitive(42, StandardType.IntType)
+        )
+      )
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(setValue)
+
+      assert(encoded)(isSubtype[AttributeValue.List](anything))
+    },
+    test("encodes DynamicValue.SomeValue") {
+      val someValue = DynamicValue.SomeValue(DynamicValue.Primitive("test", StandardType.StringType))
+      val encoded   = Codec.encoder(zio.schema.Schema.dynamicValue)(someValue)
+
+      assert(encoded)(equalTo(AttributeValue.String("test")))
+    },
+    test("encodes DynamicValue.NoneValue") {
+      val noneValue = DynamicValue.NoneValue
+      val encoded   = Codec.encoder(zio.schema.Schema.dynamicValue)(noneValue)
+
+      assert(encoded)(equalTo(AttributeValue.Null))
+    },
+    test("encodes DynamicValue.Tuple") {
+      val tuple   = DynamicValue.Tuple(
+        DynamicValue.Primitive("left", StandardType.StringType),
+        DynamicValue.Primitive(42, StandardType.IntType)
+      )
+      val encoded = Codec.encoder(zio.schema.Schema.dynamicValue)(tuple)
+
+      val expected = AttributeValue.List(
+        List(
+          AttributeValue.String("left"),
+          AttributeValue.Number(BigDecimal(42))
+        )
+      )
+      assert(encoded)(equalTo(expected))
+    },
+    test("encodes DynamicValue.LeftValue") {
+      val leftValue = DynamicValue.LeftValue(DynamicValue.Primitive("error", StandardType.StringType))
+      val encoded   = Codec.encoder(zio.schema.Schema.dynamicValue)(leftValue)
+
+      val expected = AttributeValue.Map(
+        Map(
+          AttributeValue.String("Left") -> AttributeValue.String("error")
+        )
+      )
+      assert(encoded)(equalTo(expected))
+    },
+    test("encodes DynamicValue.RightValue") {
+      val rightValue = DynamicValue.RightValue(DynamicValue.Primitive(42, StandardType.IntType))
+      val encoded    = Codec.encoder(zio.schema.Schema.dynamicValue)(rightValue)
+
+      val expected = AttributeValue.Map(
+        Map(
+          AttributeValue.String("Right") -> AttributeValue.Number(BigDecimal(42))
+        )
+      )
+      assert(encoded)(equalTo(expected))
+    },
+    test("encodes DynamicValue.Singleton") {
+      val singleton = DynamicValue.Singleton(TypeId.Structural)
+      val encoded   = Codec.encoder(zio.schema.Schema.dynamicValue)(singleton)
+
+      assert(encoded)(equalTo(AttributeValue.Map(ListMap.empty)))
+    },
+    test("throws exception for DynamicValue.Enumeration") {
+      val enumValue =
+        DynamicValue.Enumeration(TypeId.Structural, "test" -> DynamicValue.Primitive("value", StandardType.StringType))
+
+      assert(
+        try {
+          Codec.encoder(zio.schema.Schema.dynamicValue)(enumValue)
+          false
+        } catch {
+          case ex: Exception => ex.getMessage.contains("DynamicValue.Enumeration is not supported")
+        }
+      )(isTrue)
+    },
+    test("throws exception for DynamicValue.Dictionary") {
+      val dictValue = DynamicValue.Dictionary(Chunk.empty)
+
+      assert(
+        try {
+          Codec.encoder(zio.schema.Schema.dynamicValue)(dictValue)
+          false
+        } catch {
+          case ex: Exception => ex.getMessage.contains("DynamicValue.Dictionary is not supported")
+        }
+      )(isTrue)
+    },
+    test("throws exception for DynamicValue.BothValue") {
+      val bothValue = DynamicValue.BothValue(
+        DynamicValue.Primitive("left", StandardType.StringType),
+        DynamicValue.Primitive("right", StandardType.StringType)
+      )
+
+      assert(
+        try {
+          Codec.encoder(zio.schema.Schema.dynamicValue)(bothValue)
+          false
+        } catch {
+          case ex: Exception => ex.getMessage.contains("DynamicValue.BothValue is not supported")
+        }
+      )(isTrue)
+    },
+    test("throws exception for DynamicValue.Error") {
+      val errorValue = DynamicValue.Error("test error")
+
+      assert(
+        try {
+          Codec.encoder(zio.schema.Schema.dynamicValue)(errorValue)
+          false
+        } catch {
+          case ex: Exception => ex.getMessage.contains("DynamicValue.Error is not supported")
+        }
+      )(isTrue)
+    }
+  )
+
+  private val dynamicDecoderSuite = suite("DynamicDecoder Suite")(
+    test("decodes AttributeValue.String to DynamicValue.Primitive") {
+      val av      = AttributeValue.String("test")
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.Primitive("test", StandardType.StringType)
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decodes AttributeValue.Number to DynamicValue.Primitive") {
+      val av      = AttributeValue.Number(BigDecimal(42))
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.Primitive(BigDecimal(42).bigDecimal, StandardType.BigDecimalType)
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decodes AttributeValue.Bool to DynamicValue.Primitive") {
+      val av      = AttributeValue.Bool(true)
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.Primitive(true, StandardType.BoolType)
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decodes AttributeValue.Binary to DynamicValue.Primitive") {
+      val binary  = Chunk.fromArray("test".getBytes)
+      val av      = AttributeValue.Binary(binary)
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.Primitive(binary, StandardType.BinaryType)
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decodes AttributeValue.Null to DynamicValue.NoneValue") {
+      val av      = AttributeValue.Null
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      assert(decoded)(isRight(equalTo(DynamicValue.NoneValue)))
+    },
+    test("decodes AttributeValue.StringSet to DynamicValue.SetValue") {
+      val av      = AttributeValue.StringSet(Set("first", "second"))
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.SetValue(
+        Set(
+          DynamicValue.Primitive("first", StandardType.StringType),
+          DynamicValue.Primitive("second", StandardType.StringType)
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decodes AttributeValue.NumberSet to DynamicValue.SetValue") {
+      val av      = AttributeValue.NumberSet(Set(BigDecimal(1), BigDecimal(2)))
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.SetValue(
+        Set(
+          DynamicValue.Primitive(BigDecimal(1).bigDecimal, StandardType.BigDecimalType),
+          DynamicValue.Primitive(BigDecimal(2).bigDecimal, StandardType.BigDecimalType)
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decodes AttributeValue.BinarySet to DynamicValue.SetValue") {
+      val binary1 = Chunk.fromArray("test1".getBytes)
+      val binary2 = Chunk.fromArray("test2".getBytes)
+      val av      = AttributeValue.BinarySet(Set(binary1, binary2))
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.SetValue(
+        Set(
+          DynamicValue.Primitive(binary1, StandardType.BinaryType),
+          DynamicValue.Primitive(binary2, StandardType.BinaryType)
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decodes AttributeValue.List to DynamicValue.Sequence") {
+      val av      = AttributeValue.List(
+        List(
+          AttributeValue.String("first"),
+          AttributeValue.String("second")
+        )
+      )
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.Sequence(
+        Chunk(
+          DynamicValue.Primitive("first", StandardType.StringType),
+          DynamicValue.Primitive("second", StandardType.StringType)
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decodes AttributeValue.Map to DynamicValue.Record") {
+      val av      = AttributeValue.Map(
+        Map(
+          AttributeValue.String("name") -> AttributeValue.String("John"),
+          AttributeValue.String("age")  -> AttributeValue.Number(BigDecimal(30))
+        )
+      )
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.Record(
+        TypeId.parse("AttributeValue.Map"),
+        ListMap(
+          "name" -> DynamicValue.Primitive("John", StandardType.StringType),
+          "age"  -> DynamicValue.Primitive(BigDecimal(30).bigDecimal, StandardType.BigDecimalType)
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decodes empty AttributeValue.List to empty DynamicValue.Sequence") {
+      val av      = AttributeValue.List(List.empty)
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.Sequence(Chunk.empty)
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decodes empty AttributeValue.Map to empty DynamicValue.Record") {
+      val av      = AttributeValue.Map(Map.empty)
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.Record(
+        TypeId.parse("AttributeValue.Map"),
+        ListMap.empty
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decodes nested AttributeValue.Map") {
+      val av      = AttributeValue.Map(
+        Map(
+          AttributeValue.String("outer") -> AttributeValue.Map(
+            Map(
+              AttributeValue.String("inner") -> AttributeValue.String("value")
+            )
+          )
+        )
+      )
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.Record(
+        TypeId.parse("AttributeValue.Map"),
+        ListMap(
+          "outer" -> DynamicValue.Record(
+            TypeId.parse("AttributeValue.Map"),
+            ListMap(
+              "inner" -> DynamicValue.Primitive("value", StandardType.StringType)
+            )
+          )
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("decodes nested AttributeValue.List") {
+      val av      = AttributeValue.List(
+        List(
+          AttributeValue.List(
+            List(
+              AttributeValue.String("nested")
+            )
+          )
+        )
+      )
+      val decoded = Codec.decoder(zio.schema.Schema.dynamicValue)(av)
+
+      val expected = DynamicValue.Sequence(
+        Chunk(
+          DynamicValue.Sequence(
+            Chunk(
+              DynamicValue.Primitive("nested", StandardType.StringType)
+            )
+          )
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    }
+  )
+
+  private val dynamicRoundTripSuite = suite("Dynamic Round-trip Suite")(
+    test("round-trip String primitive") {
+      val original = DynamicValue.Primitive("test", StandardType.StringType)
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip Boolean primitive") {
+      val original = DynamicValue.Primitive(true, StandardType.BoolType)
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip BigDecimal primitive") {
+      val original = DynamicValue.Primitive(BigDecimal("123.45").bigDecimal, StandardType.BigDecimalType)
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      assert(decoded.map(_.asInstanceOf[DynamicValue.Primitive[_]].value.asInstanceOf[java.math.BigDecimal]))(
+        isRight(equalTo(BigDecimal("123.45").bigDecimal))
+      )
+    },
+    test("round-trip Binary primitive") {
+      val binary   = Chunk.fromArray("test".getBytes)
+      val original = DynamicValue.Primitive(binary, StandardType.BinaryType)
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      assert(decoded)(isRight(equalTo(DynamicValue.Primitive(binary, StandardType.BinaryType))))
+    },
+    test("round-trip Record") {
+      val original = DynamicValue.Record(
+        TypeId.Structural,
+        ListMap(
+          "name" -> DynamicValue.Primitive("John", StandardType.StringType),
+          "age"  -> DynamicValue.Primitive(BigDecimal(30).bigDecimal, StandardType.BigDecimalType)
+        )
+      )
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      val expected = DynamicValue.Record(
+        TypeId.parse("AttributeValue.Map"),
+        ListMap(
+          "name" -> DynamicValue.Primitive("John", StandardType.StringType),
+          "age"  -> DynamicValue.Primitive(BigDecimal(30).bigDecimal, StandardType.BigDecimalType)
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("round-trip Sequence") {
+      val original = DynamicValue.Sequence(
+        Chunk(
+          DynamicValue.Primitive("first", StandardType.StringType),
+          DynamicValue.Primitive("second", StandardType.StringType)
+        )
+      )
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip StringSet") {
+      val original = DynamicValue.SetValue(
+        Set(
+          DynamicValue.Primitive("first", StandardType.StringType),
+          DynamicValue.Primitive("second", StandardType.StringType)
+        )
+      )
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip NumberSet") {
+      val original = DynamicValue.SetValue(
+        Set(
+          DynamicValue.Primitive(BigDecimal(1).bigDecimal, StandardType.BigDecimalType),
+          DynamicValue.Primitive(BigDecimal(2).bigDecimal, StandardType.BigDecimalType)
+        )
+      )
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      val expected = DynamicValue.SetValue(
+        Set(
+          DynamicValue.Primitive(BigDecimal(1).bigDecimal, StandardType.BigDecimalType),
+          DynamicValue.Primitive(BigDecimal(2).bigDecimal, StandardType.BigDecimalType)
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("round-trip NoneValue") {
+      val original = DynamicValue.NoneValue
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      assert(decoded)(isRight(equalTo(original)))
+    },
+    test("round-trip SomeValue") {
+      val original = DynamicValue.SomeValue(DynamicValue.Primitive("test", StandardType.StringType))
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      // SomeValue encoding unwraps the value, so decoder won't restore the SomeValue wrapper
+      val expected = DynamicValue.Primitive("test", StandardType.StringType)
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("round-trip Tuple") {
+      val original = DynamicValue.Tuple(
+        DynamicValue.Primitive("left", StandardType.StringType),
+        DynamicValue.Primitive(BigDecimal(42).bigDecimal, StandardType.BigDecimalType)
+      )
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      // Tuple becomes a Sequence after round-trip
+      val expected = DynamicValue.Sequence(
+        Chunk(
+          DynamicValue.Primitive("left", StandardType.StringType),
+          DynamicValue.Primitive(BigDecimal(42).bigDecimal, StandardType.BigDecimalType)
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("round-trip LeftValue") {
+      val original = DynamicValue.LeftValue(DynamicValue.Primitive("error", StandardType.StringType))
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      // LeftValue becomes a Record after round-trip
+      val expected = DynamicValue.Record(
+        TypeId.parse("AttributeValue.Map"),
+        ListMap(
+          "Left" -> DynamicValue.Primitive("error", StandardType.StringType)
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    },
+    test("round-trip RightValue") {
+      val original =
+        DynamicValue.RightValue(DynamicValue.Primitive(BigDecimal(42).bigDecimal, StandardType.BigDecimalType))
+      val encoded  = Codec.encoder(zio.schema.Schema.dynamicValue)(original)
+      val decoded  = Codec.decoder(zio.schema.Schema.dynamicValue)(encoded)
+
+      // RightValue becomes a Record after round-trip
+      val expected = DynamicValue.Record(
+        TypeId.parse("AttributeValue.Map"),
+        ListMap(
+          "Right" -> DynamicValue.Primitive(BigDecimal(42).bigDecimal, StandardType.BigDecimalType)
+        )
+      )
+      assert(decoded)(isRight(equalTo(expected)))
+    }
+  )
+}


### PR DESCRIPTION
Handling logic for DynamicValue <-> AttributeValue was mostly copied from zio-schema-json which does DynamicValue <-> Json [here](https://github.com/zio/zio-schema/blob/6bbe79cbc2d081162092562b84f2b8720a1bcf96/zio-schema-json/shared/src/main/scala/zio/schema/codec/package.scala).

I also added some extra unit tests to test `zio.json.ast.Json` conversion using the `Schema[Json]` from `zio.schema.codec.json.schemaJson` as I assume `Json` will be the most common use case for `DynamicValue`

Fixes https://github.com/zio/zio-dynamodb/issues/636