### PR TITLE
Generic Record Decoder improvements, should take into account the schema field type

### DIFF
--- a/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
@@ -575,15 +575,25 @@ private[dynamodb] object Codec {
           case AttributeValue.Map(map) =>
             structure.toChunk.forEach {
               case Schema.Field(key, schema: Schema[a], _, _, _, _) =>
-                map.get(AttributeValue.String(key)) match {
-                  case Some(av) =>
-                    val dec = decoder(schema)
-                    dec(av) match {
-                      case Right(value) => Right(key -> value)
-                      case Left(s)      => Left(s)
-                    }
-                  case None     => Right(key -> None)
-                }
+                val dec          = decoder(schema)
+                val k            = key // @fieldName is respected by the zio-schema macro
+                val maybeAv      = map.get(AttributeValue.String(k))
+                val errorOrValue =
+                  maybeAv
+                    .toRight(DecodingError(s"field '$k' not found in AttributeValue map"))
+                    .flatMap(dec)
+                    .map(k -> _)
+                if (maybeAv.isEmpty)
+                  ContainerField.containerField(schema) match {
+                    case ContainerField.Optional => Right(k -> None)
+                    case ContainerField.Chunk    => Right(k -> Chunk.empty)
+                    case ContainerField.Sequence => Right(k -> List.empty)
+                    case ContainerField.Map      => Right(k -> Map.empty)
+                    case ContainerField.Set      => Right(k -> Set.empty)
+                    case ContainerField.Scalar   => errorOrValue
+                  }
+                else
+                  errorOrValue
             }
               .map(ls => ListMap.newBuilder.++=(ls).result())
           case av                      => Left(DecodingError(s"Expected AttributeValue.Map but found ${av.showType}"))

--- a/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
@@ -586,11 +586,7 @@ private[dynamodb] object Codec {
                 if (maybeAv.isEmpty)
                   ContainerField.containerField(schema) match {
                     case ContainerField.Optional => Right(k -> None)
-                    case ContainerField.Chunk    => Right(k -> Chunk.empty)
-                    case ContainerField.Sequence => Right(k -> List.empty)
-                    case ContainerField.Map      => Right(k -> Map.empty)
-                    case ContainerField.Set      => Right(k -> Set.empty)
-                    case ContainerField.Scalar   => errorOrValue
+                    case _                       => errorOrValue
                   }
                 else
                   errorOrValue

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/CodecRoundTripSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/CodecRoundTripSpec.scala
@@ -395,6 +395,41 @@ object CodecRoundTripSpec extends ZIOSpecDefault with CodecTestFixtures {
         !itemBig.map.values.exists(_ == AttributeValue.Null) &&
           !itemCase21.map.values.exists(_ == AttributeValue.Null)
       )
+    },
+    test("encodes Case21Option with empty values, decodes to Case21List with empty values") {
+      // format: off
+      val case21Option = Case21(
+        "id", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10",
+        "f11", "f12", "f13", "f14", "f15", "f16", "f17", None, None
+      )
+      val case21List = Case21List(
+        "id", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10",
+        "f11", "f12", "f13", "f14", "f15", "f16", "f17", Nil, Nil
+      )
+      // format: on
+
+      val itemCase21Option  = DynamoDBQuery.toItem(case21Option)
+      val itemCase21Decoded = DynamoDBQuery.fromItem[Case21List](itemCase21Option)
+      assert(itemCase21Decoded)(isRight(equalTo(case21List)))
+    },
+    test("encodes BigOption with empty values, decodes to BigList with empty values") {
+      // format: off
+      val bigOption = Big(
+        "id", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10",
+        "f11", "f12", "f13", "f14", "f15", "f16", "f17", None, None,
+        None, None, None, None, None, None, None, None, None, None, None
+      )
+      val bigList = BigList(
+        "id", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10",
+        "f11", "f12", "f13", "f14", "f15", "f16", "f17", Nil, Nil,
+        Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil
+      )
+      // format: on
+
+      val itemBigOption  = DynamoDBQuery.toItem(bigOption)
+      val bigListDecoded = DynamoDBQuery.fromItem[BigList](itemBigOption)
+
+      assert(bigListDecoded)(isRight(equalTo(bigList)))
     }
   )
 

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/CodecRoundTripSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/CodecRoundTripSpec.scala
@@ -1,8 +1,9 @@
 package zio.dynamodb.codec
 
+import zio.dynamodb.DynamoDBError.ItemError.DecodingError
 import zio.dynamodb.{ AttributeValue, Codec, DynamoDBQuery }
 import zio.schema.{ DeriveSchema, Schema, StandardType }
-import zio.test.Assertion.{ equalTo, isRight }
+import zio.test.Assertion.{ equalTo, isLeft, isRight }
 import zio.test._
 import zio.{ Chunk, ZIO }
 
@@ -419,17 +420,12 @@ object CodecRoundTripSpec extends ZIOSpecDefault with CodecTestFixtures {
         "f11", "f12", "f13", "f14", "f15", "f16", "f17", None, None,
         None, None, None, None, None, None, None, None, None, None, None
       )
-      val bigList = BigList(
-        "id", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10",
-        "f11", "f12", "f13", "f14", "f15", "f16", "f17", Nil, Nil,
-        Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil
-      )
       // format: on
 
       val itemBigOption  = DynamoDBQuery.toItem(bigOption)
       val bigListDecoded = DynamoDBQuery.fromItem[BigList](itemBigOption)
 
-      assert(bigListDecoded)(isRight(equalTo(bigList)))
+      assert(bigListDecoded)(isLeft(equalTo(DecodingError(message = "field 'f18' not found in AttributeValue map"))))
     }
   )
 

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/models.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/models.scala
@@ -203,6 +203,42 @@ object Case21 {
 }
 
 // format: off
+case class Case21List(
+  id: String, f0: String, f1: String, f2: String, f3: String, f4: String, f5: String, f6: String, f7: String, f8: String, f9: String,
+  f10: String, f11: String, f12: String, f13: String, f14: String, f15: String, f16: String, f17: String, f18: List[String], f19: List[String]
+)
+// format: on
+object Case21List {
+  implicit val schema: Schema.CaseClass21[
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    String,
+    List[String],
+    List[String],
+    Case21List
+  ] =
+    DeriveSchema.gen[Case21List]
+
+  val id: ProjectionExpression[Case21List, String] = ProjectionExpression.$$("id")
+}
+
+// format: off
 case class Big(
   id: String, f0: String, f1: String, f2: String, f3: String, f4: String, f5: String, f6: String, f7: String, f8: String, f9: String,
   f10: String, f11: String, f12: String, f13: String, f14: String, f15: String, f16: String, f17: String, f18: Option[String], f19: Option[String],
@@ -214,4 +250,18 @@ object Big {
   implicit val schema: Schema[Big] = DeriveSchema.gen[Big]
 
   val id: ProjectionExpression[Big, String] = ProjectionExpression.$$("id")
+}
+
+// format: off
+case class BigList(
+  id: String, f0: String, f1: String, f2: String, f3: String, f4: String, f5: String, f6: String, f7: String, f8: String, f9: String,
+  f10: String, f11: String, f12: String, f13: String, f14: String, f15: String, f16: String, f17: String, f18: List[String], f19: List[String],
+  f20: List[String], f21: List[String], f22: List[String], f23: List[String], f24: List[String], f25: List[String], f26: List[String], f27: List[String],
+  f28: List[String], f29: List[String], f30: List[String],
+)
+// format: on
+object BigList {
+  implicit val schema: Schema[BigList] = DeriveSchema.gen[BigList]
+
+  val id: ProjectionExpression[BigList, String] = ProjectionExpression.$$("id")
 }


### PR DESCRIPTION
This PR is a followup for #701 and covers a wonderful suggestion by @googley42 (https://github.com/zio/zio-dynamodb/pull/701#discussion_r2324303331)

All tests pass and also tried internally! We probabable need to add tests for all of the edge cases though :D 
