### PR TITLE
improve error and defect propagation at the `refineOrDie` boundary

### DIFF
--- a/docs/reference/error-handling.md
+++ b/docs/reference/error-handling.md
@@ -26,3 +26,4 @@ The error hierarchy is as follows:
     - **`DynamoDBError.TransactionError.EmptyTransaction`**
     - **`DynamoDBError.TransactionError.MixedTransactionTypes`**
     - **`DynamoDBError.TransactionError.InvalidTransactionActions`**
+  - **`DynamoDBError.UnknownNonFatalError`** Encapsulates a non-fatal error (as defined by scala.utils.control.NonFatal) that occurred during processing

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBError.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBError.scala
@@ -30,6 +30,14 @@ object DynamoDBError {
   }
 
   /**
+   * Encapsulates a Non Fatal error (as defined by scala.utils.control.NonFatal) that occurred during processing
+   */
+  final case class UnknownError(cause: Throwable) extends DynamoDBError {
+    override def message: String = cause.getMessage
+  }
+  // TODO: Avi - create an unapply method that tests for NonFatal
+
+  /**
    * You need to consider this error if queries result in batching eg if you are using `DynamoDBQuery.batch` or manually `Zip`'ing
    * together `DynamoDBQuery`'s or using utility functions that use `DynamoDBQuery.batch`.
    * Note at the point that this error is raised automatic retries have already occurred.

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBError.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBError.scala
@@ -30,7 +30,7 @@ object DynamoDBError {
   }
 
   /**
-   * Encapsulates a Non Fatal error (as defined by scala.utils.control.NonFatal) that occurred during processing
+   * Encapsulates a non-fatal error (as defined by scala.utils.control.NonFatal) that occurred during processing
    */
   final case class UnknownNonFatalError(cause: Throwable) extends DynamoDBError {
     override def message: String = cause.getMessage

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBError.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBError.scala
@@ -32,10 +32,9 @@ object DynamoDBError {
   /**
    * Encapsulates a Non Fatal error (as defined by scala.utils.control.NonFatal) that occurred during processing
    */
-  final case class UnknownError(cause: Throwable) extends DynamoDBError {
+  final case class UnknownNonFatalError(cause: Throwable) extends DynamoDBError {
     override def message: String = cause.getMessage
   }
-  // TODO: Avi - create an unapply method that tests for NonFatal
 
   /**
    * You need to consider this error if queries result in batching eg if you are using `DynamoDBQuery.batch` or manually `Zip`'ing

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -140,7 +140,7 @@ private[dynamodb] final case class DynamoDBExecutorImpl private[dynamodb] (dynam
     result.refineOrDie {
       case e: AwsSdkDynamoDbException          => DynamoDBError.AWSError(e)
       case e: DynamoDBError                    => e
-      case e if scala.util.control.NonFatal(e) => DynamoDBError.UnknownError(e)
+      case e if scala.util.control.NonFatal(e) => DynamoDBError.UnknownNonFatalError(e)
     }
   }
 

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -138,8 +138,9 @@ private[dynamodb] final case class DynamoDBExecutorImpl private[dynamodb] (dynam
     }
 
     result.refineOrDie {
-      case e: AwsSdkDynamoDbException => DynamoDBError.AWSError(e)
-      case e: DynamoDBError           => e
+      case e: AwsSdkDynamoDbException          => DynamoDBError.AWSError(e)
+      case e: DynamoDBError                    => e
+      case e if scala.util.control.NonFatal(e) => DynamoDBError.UnknownError(e)
     }
   }
 

--- a/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
@@ -1,5 +1,6 @@
 package zio.dynamodb
 
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException
 import zio.aws.dynamodb.model.primitives.{ AttributeName, StringAttributeValue, TableArn }
 import zio.aws.dynamodb.model.{
   BatchWriteItemResponse,
@@ -22,7 +23,6 @@ import zio.test.Assertion.isSubtype
 import zio.test.Assertion
 import zio.test.assert
 import zio.Chunk
-
 import zio.schema.DeriveSchema
 import zio.test.Spec
 
@@ -183,21 +183,72 @@ object AutoBatchedFailureSpec extends ZIOSpecDefault with DynamoDBFixtures {
       )
     )
 
-  val errorReturnMockBatchGet: ULayer[DynamoDb] = DynamoDbMock
+  private val aswSdkException = DynamoDbException
+    .builder()
+    .message("BOOOOOOM!")
+    .build()
+
+  private val nonFatalError: IllegalStateException = new IllegalStateException("BOOOOOOM!")
+
+  private val nonFatalErrorReturnMockBatchGet: ULayer[DynamoDb] = DynamoDbMock
+    .BatchGetItem(equalTo(getRequestItemOneAndTwo()), failure(zio.aws.core.AwsError.fromThrowable(nonFatalError)))
+
+  private val awsSdkErrorReturnMockBatchGet: ULayer[DynamoDb] = DynamoDbMock
+    .BatchGetItem(equalTo(getRequestItemOneAndTwo()), failure(zio.aws.core.AwsError.fromThrowable(aswSdkException)))
+
+  private val zioDdbErrorReturnMockBatchGet: ULayer[DynamoDb] = DynamoDbMock
     .BatchGetItem(
       equalTo(getRequestItemOneAndTwo()),
-      failure(zio.aws.core.AwsError.fromThrowable(new IllegalStateException("BOOOOOOM!")))
+      failure(zio.aws.core.AwsError.fromThrowable(DynamoDBError.TransactionError.MixedTransactionTypes))
+    )
+
+  private val fatalError: Throwable                          = new VirtualMachineError("BADOOOOOOSH!") {}
+  private val fatalErrorReturnMockBatchGet: ULayer[DynamoDb] = DynamoDbMock
+    .BatchGetItem(
+      equalTo(getRequestItemOneAndTwo()),
+      failure(zio.aws.core.AwsError.fromThrowable(fatalError))
     )
 
   private val batchGetSuite =
     suite("batch gets")(
-      suite("with defects")(test("should die when BatchGetItem returns AWS error") {
-        val autoBatched =
-          getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)
-        for {
-          exit <- autoBatched.execute.exit
-        } yield assert(exit)(dies(isSubtype[IllegalStateException](hasMessage(containsString("BOOOOOOM!")))))
-      }).provideLayer(errorReturnMockBatchGet >>> DynamoDBExecutor.live) @@ TestAspect.withLiveClock,
+      suite("Non Fatal errors get propagated")(
+        test("should fail when BatchGetItem returns an AWS SDK error") {
+          val autoBatched =
+            getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)
+          for {
+            exit <- autoBatched.execute.exit
+          } yield assert(exit)(
+            fails(
+              isSubtype[DynamoDBError.AWSError]( // we expect a ZIO DynamoDBError wrapping the AWS SDK exception
+                anything
+              )
+            )
+          )
+        }.provideLayer(awsSdkErrorReturnMockBatchGet >>> DynamoDBExecutor.live),
+        test("should fail when BatchGetItem returns a ZIO DynamoDBError") {
+          val autoBatched =
+            getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)
+          for {
+            exit <- autoBatched.execute.exit
+          } yield assert(exit)(
+            fails(isSubtype[DynamoDBError.TransactionError.MixedTransactionTypes.type](anything))
+          )
+        }.provideLayer(zioDdbErrorReturnMockBatchGet >>> DynamoDBExecutor.live),
+        test("should fail when BatchGetItem returns a non fatal error") {
+          val autoBatched =
+            getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)
+          for {
+            exit <- autoBatched.execute.exit
+          } yield assert(exit)(fails(isSubtype[DynamoDBError.UnknownError](hasMessage(containsString("BOOOOOOM!")))))
+        }.provideLayer(nonFatalErrorReturnMockBatchGet >>> DynamoDBExecutor.live),
+        test("should die when BatchGetItem returns a fatal error") {
+          val autoBatched =
+            getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)
+          for {
+            exit <- autoBatched.execute.exit
+          } yield assert(exit)(dies(isSubtype[VirtualMachineError](anything)))
+        }.provideLayer(fatalErrorReturnMockBatchGet >>> DynamoDBExecutor.live)
+      ) @@ TestAspect.withLiveClock,
       suite("successful batch gets")(test("should retry when there are unprocessed keys") {
         val autoBatched = getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)
         assertZIO(autoBatched.execute.exit)(succeeds(anything))

--- a/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
@@ -239,7 +239,7 @@ object AutoBatchedFailureSpec extends ZIOSpecDefault with DynamoDBFixtures {
             getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)
           for {
             exit <- autoBatched.execute.exit
-          } yield assert(exit)(fails(isSubtype[DynamoDBError.UnknownError](hasMessage(containsString("BOOOOOOM!")))))
+          } yield assert(exit)(fails(isSubtype[DynamoDBError.UnknownNonFatalError](hasMessage(containsString("BOOOOOOM!")))))
         }.provideLayer(nonFatalErrorReturnMockBatchGet >>> DynamoDBExecutor.live),
         test("should die when BatchGetItem returns a fatal error") {
           val autoBatched =

--- a/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/AutoBatchedFailureSpec.scala
@@ -239,7 +239,9 @@ object AutoBatchedFailureSpec extends ZIOSpecDefault with DynamoDBFixtures {
             getItem("mockBatches", itemOne) zip getItem("mockBatches", itemTwo)
           for {
             exit <- autoBatched.execute.exit
-          } yield assert(exit)(fails(isSubtype[DynamoDBError.UnknownNonFatalError](hasMessage(containsString("BOOOOOOM!")))))
+          } yield assert(exit)(
+            fails(isSubtype[DynamoDBError.UnknownNonFatalError](hasMessage(containsString("BOOOOOOM!"))))
+          )
         }.provideLayer(nonFatalErrorReturnMockBatchGet >>> DynamoDBExecutor.live),
         test("should die when BatchGetItem returns a fatal error") {
           val autoBatched =


### PR DESCRIPTION
attempts to fix https://github.com/zio/zio-dynamodb/issues/718