### PR TITLE
CI: Add JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['17', '21']
+        java: ['17', '21', '25']
         scala: ['3.3', '2.13']
     env:
       AWS_ACCESS_KEY_ID: dummykey


### PR DESCRIPTION
## Summary
- Add JDK 25 to the CI test matrix
- Test matrix is now: JDK 17, 21, 25