### PR TITLE
Upgrade to Scala 3.3.8, add @unchecked for 3 newly-flagged type tests

### DIFF
--- a/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
@@ -824,14 +824,14 @@ private[dynamodb] object Codec {
     private def tupleDecoder[A, B](decL: Decoder[A], decR: Decoder[B]): Decoder[(A, B)] =
       (av: AttributeValue) =>
         av match {
-          case AttributeValue.List(list: Seq[AttributeValue]) if list.size == 2 =>
+          case AttributeValue.List(list: (Seq[AttributeValue] @unchecked)) if list.size == 2 =>
             val avA = list(0)
             val avB = list(1)
             for {
               a <- decL(avA)
               b <- decR(avB)
             } yield (a, b)
-          case av                                                               =>
+          case av                                                                            =>
             Left(DecodingError(s"Expected an AttributeValue.List of two elements but found type ${av.showType}"))
         }
 

--- a/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/DynamoDBExecutorImpl.scala
@@ -124,10 +124,10 @@ private[dynamodb] final case class DynamoDBExecutorImpl private[dynamodb] (dynam
   override def execute[A](query: DynamoDBQuery[_, A]): ZIO[Any, DynamoDBError, A] = {
 
     val result = query match {
-      case constructor: Constructor[_, A] => executeConstructor(constructor)
-      case zip @ Zip(_, _, _, _)          => executeZip(zip)
-      case map @ Map(_, _)                => executeMap(map)
-      case Absolve(query)                 =>
+      case constructor: (Constructor[_, A] @unchecked) => executeConstructor(constructor)
+      case zip @ Zip(_, _, _, _)                       => executeZip(zip)
+      case map @ Map(_, _)                             => executeMap(map)
+      case Absolve(query)                              =>
         for {
           errorOrA <- execute(query)
           a        <- errorOrA match {
@@ -443,7 +443,7 @@ case object DynamoDBExecutorImpl {
     (Chunk[Constructor[Any, Any]], Chunk[Any] => A)
   ] =
     query match {
-      case constructor: Constructor[_, A] =>
+      case constructor: (Constructor[_, A] @unchecked) =>
         constructor match {
           case s: PutItem                  => Right((Chunk(s), chunk => chunk(0).asInstanceOf[A]))
           case s: DeleteItem               => Right((Chunk(s), chunk => chunk(0).asInstanceOf[A]))
@@ -496,7 +496,7 @@ case object DynamoDBExecutorImpl {
               )
             )
         }
-      case Zip(left, right, zippable, _)  =>
+      case Zip(left, right, zippable, _)               =>
         for {
           l <- buildTransaction(left)
           r <- buildTransaction(right)
@@ -512,11 +512,11 @@ case object DynamoDBExecutorImpl {
             zippable.zip(leftValue, rightValue)
           }
         )
-      case Map(query, mapper)             =>
+      case Map(query, mapper)                          =>
         buildTransaction(query).map {
           case (constructors, construct) => (constructors, chunk => mapper.asInstanceOf[Any => A](construct(chunk)))
         }
-      case Absolve(query)                 =>
+      case Absolve(query)                              =>
         Left(
           DynamoDBError.TransactionError.InvalidTransactionActions(
             NonEmptyChunk(query.asInstanceOf[DynamoDBQuery[Any, Any]])

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -6,7 +6,7 @@ import sbtbuildinfo.BuildInfoKeys.*
 object BuildHelper {
   // Align with zio-schema since we have a deep dependency on it
   val Scala213                = "2.13.18"
-  val Scala3                  = "3.3.7"
+  val Scala3                  = "3.3.8"
   private val SilencerVersion = "1.7.19"
 
   private val stdOptions = Seq(


### PR DESCRIPTION
3.3.8 (current LTS) tightened pattern-match/type-checker precision (exhaustivity via upper bounds of abstract types, GADT TypeTest trust, erasure-phase fixes — see the 3.3.8 release notes) enough to newly detect 3 pre-existing unchecked type tests that -Xfatal-warnings turns into hard errors:

- Codec.scala: AttributeValue.List's field is Iterable[AttributeValue]; narrowing to Seq[AttributeValue] in tupleDecoder can't be verified by the compiler under erasure, though it's safe by construction (encoder always produces a concrete Seq for a 2-tuple).
- DynamoDBExecutorImpl.scala (x2): narrowing a wildcard existential DynamoDBQuery[_, A] down to Constructor[_, A] hits the same erasure limitation.

None of these are new bugs from the version bump — they're routine LTS patch fallout, made build-breaking only by -Xfatal-warnings. Originally surfaced by Scala Steward PR #871, which failed CI without a root-cause explanation; reproduced locally here to confirm and fix precisely.

Verified: zio-dynamodb/test passes (589 tests) on both 2.13.18 and 3.3.8, `check` (scalafmt) passes, full Test/compile clean across all modules on both Scala versions.