### PR TITLE
add "it" module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,6 +157,23 @@ lazy val ceInterpreter = (project in file("ce"))
     testFrameworks     := Seq(new TestFramework("munit.Framework"))
   )
 
+lazy val it = (project in file("it"))
+  .dependsOn(zioInterpreter, ceInterpreter, futureInterpreter, schemaDynamodb, schemaDdbExpr)
+  .settings(
+    name                     := "zio-dynamodb-it",
+    publish / skip           := true,
+    crossScalaVersions       := Seq(scala213Version, scala3Version),
+    libraryDependencies ++= Seq(
+      "dev.zio"               %% "zio-test"         % zioVersion,
+      "dev.zio"               %% "zio-test-sbt"     % zioVersion,
+      "org.testcontainers"     % "testcontainers"   % "1.21.3",
+      "software.amazon.awssdk" % "netty-nio-client" % awsSdkVersion,
+      "org.slf4j"              % "slf4j-nop"        % "2.0.16"
+    ),
+    testFrameworks           := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
+    Test / parallelExecution := false
+  )
+
 lazy val docs = project
   .in(file("zio-dynamodb-docs"))
   .settings(
@@ -184,7 +201,7 @@ lazy val docs = project
   .enablePlugins(WebsitePlugin)
 
 lazy val root = (project in file("."))
-  .aggregate(core, aws, schemaDynamodb, zioInterpreter, schemaDdbExpr, futureInterpreter, ceInterpreter, docs)
+  .aggregate(core, aws, schemaDynamodb, zioInterpreter, schemaDdbExpr, futureInterpreter, ceInterpreter, it, docs)
   .enablePlugins(zio.sbt.ZioSbtCiPlugin)
   .settings(
     name              := "zio-dynamodb",

--- a/it/src/test/scala/zio/dynamodb/BatchSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/BatchSpec.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2021-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.dynamodb
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import zio._
+import zio.test._
+import zio.test.Assertion.{ anything, isSubtype }
+
+import java.util.UUID
+
+object BatchSpec extends DynamoDBLocalSpec {
+
+  private def withTable(
+    interp: AwsInterpreter[Task]
+  )(
+    f: (String, AwsInterpreter[Task]) => ZIO[Any, Throwable, TestResult]
+  ): Task[TestResult] =
+    ZIO.scoped {
+      for {
+        tableName <- ZIO.succeed(s"test-bu-${UUID.randomUUID()}")
+        _         <- interp.run(singleIdKeyTable(tableName))
+        _         <- ZIO.addFinalizer(interp.run(DynamoDBQuery.deleteTable(tableName)).orDie)
+        result    <- f(tableName, interp)
+      } yield result
+    }
+
+  def spec = suite("Batch IT")(
+    suite("runWriteItem")(
+      test("returns Complete when all items processed") {
+        for {
+          client <- ZIO.service[DynamoDbAsyncClient]
+          interp = ZioInterpreter.fromAsyncClient(client)
+          result <- withTable(interp) { (table, interp) =>
+                      val items = List(
+                        Item("id" -> "a", "v" -> 1),
+                        Item("id" -> "b", "v" -> 2),
+                        Item("id" -> "c", "v" -> 3)
+                      )
+                      Batch
+                        .runWriteItem(interp)(
+                          DynamoDBQuery.batchWriteItem(items)(i => DynamoDBQuery.putItem(table, i))
+                        )
+                        .map(r => assert(r)(isSubtype[Batch.WriteResult.Complete](anything)))
+                    }
+        } yield result
+      },
+
+      test("written items are retrievable individually") {
+        for {
+          client <- ZIO.service[DynamoDbAsyncClient]
+          interp = ZioInterpreter.fromAsyncClient(client)
+          result <- withTable(interp) { (table, interp) =>
+                      val items = List(Item("id" -> "x", "v" -> 10), Item("id" -> "y", "v" -> 20))
+                      for {
+                        _  <- Batch.runWriteItem(interp)(
+                                DynamoDBQuery.batchWriteItem(items)(i => DynamoDBQuery.putItem(table, i))
+                              )
+                        rx <- interp.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "x")))
+                        ry <- interp.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "y")))
+                      } yield assertTrue(
+                        rx.contains(Item("id" -> "x", "v" -> 10)) &&
+                          ry.contains(Item("id" -> "y", "v" -> 20))
+                      )
+                    }
+        } yield result
+      },
+
+      test("batch delete removes all targeted items") {
+        for {
+          client <- ZIO.service[DynamoDbAsyncClient]
+          interp = ZioInterpreter.fromAsyncClient(client)
+          result <- withTable(interp) { (table, interp) =>
+                      val items = List(Item("id" -> "d1"), Item("id" -> "d2"))
+                      val keys  = List(PrimaryKey("id" -> "d1"), PrimaryKey("id" -> "d2"))
+                      for {
+                        _   <- Batch.runWriteItem(interp)(
+                                 DynamoDBQuery.batchWriteItem(items)(i => DynamoDBQuery.putItem(table, i))
+                               )
+                        _   <- Batch.runWriteItem(interp)(
+                                 DynamoDBQuery.batchWriteItem(keys)(k => DynamoDBQuery.deleteItem(table, k))
+                               )
+                        rd1 <- interp.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "d1")))
+                        rd2 <- interp.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "d2")))
+                      } yield assertTrue(rd1.isEmpty && rd2.isEmpty)
+                    }
+        } yield result
+      }
+    ),
+
+    suite("runGetItem")(
+      test("returns Complete when all items exist") {
+        for {
+          client <- ZIO.service[DynamoDbAsyncClient]
+          interp = ZioInterpreter.fromAsyncClient(client)
+          result <- withTable(interp) { (table, interp) =>
+                      val ids   = List("p", "q", "r")
+                      val items = ids.map(id => Item("id" -> id))
+                      for {
+                        _      <- Batch.runWriteItem(interp)(
+                                    DynamoDBQuery.batchWriteItem(items)(i => DynamoDBQuery.putItem(table, i))
+                                  )
+                        result <-
+                          Batch.runGetItem(interp)(
+                            DynamoDBQuery.batchGetItem(ids)(id => DynamoDBQuery.GetItem(table, PrimaryKey("id" -> id)))
+                          )
+                      } yield assert(result)(isSubtype[Batch.GetResult.Complete](anything))
+                    }
+        } yield result
+      },
+
+      test("all requested items are present in the response") {
+        for {
+          client <- ZIO.service[DynamoDbAsyncClient]
+          interp = ZioInterpreter.fromAsyncClient(client)
+          result <- withTable(interp) { (table, interp) =>
+                      val ids   = List("m", "n")
+                      val items = ids.map(id => Item("id" -> id, "score" -> 42))
+                      for {
+                        _      <- Batch.runWriteItem(interp)(
+                                    DynamoDBQuery.batchWriteItem(items)(i => DynamoDBQuery.putItem(table, i))
+                                  )
+                        result <-
+                          Batch.runGetItem(interp)(
+                            DynamoDBQuery.batchGetItem(ids)(id => DynamoDBQuery.GetItem(table, PrimaryKey("id" -> id)))
+                          )
+                        found = result match {
+                                  case Batch.GetResult.Complete(r) => r.responses.getOrElse(table, Set.empty)
+                                  case _                           => Set.empty
+                                }
+                      } yield assertTrue(found.size == 2)
+                    }
+        } yield result
+      },
+
+      test("absent keys return Complete with empty responses") {
+        for {
+          client <- ZIO.service[DynamoDbAsyncClient]
+          interp = ZioInterpreter.fromAsyncClient(client)
+          result <- withTable(interp) { (table, interp) =>
+                      val ids = List("ghost-1", "ghost-2")
+                      Batch
+                        .runGetItem(interp)(
+                          DynamoDBQuery.batchGetItem(ids)(id => DynamoDBQuery.GetItem(table, PrimaryKey("id" -> id)))
+                        )
+                        .map(r => assert(r)(isSubtype[Batch.GetResult.Complete](anything)))
+                    }
+        } yield result
+      }
+    )
+  )
+}

--- a/it/src/test/scala/zio/dynamodb/DdbExprApiSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/DdbExprApiSpec.scala
@@ -1,0 +1,579 @@
+/*
+ * Copyright 2021-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.dynamodb
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
+import zio._
+import zio.blocks.chunk.Chunk
+import zio.blocks.schema.{ CompanionOptics, Lens, Schema }
+import zio.dynamodb.blocks.ddbexpr.{ DdbExprApi, DdbKeyExpr }
+import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
+import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
+import zio.dynamodb.blocks.ddbexpr.DdbExpr.{ DdbExprBoolSyntax, OpticDdbExprOps, OpticUpdateOps }
+import zio.test._
+import zio.test.Assertion._
+import zio.test.TestAspect
+
+/**
+ * Integration tests for [[DdbExprApi]].
+ *
+ *  Focuses on the correctness guarantee that distinguishes [[DdbExprApi]] from
+ *  [[zio.dynamodb.blocks.DdbSchemaExprApi]]: sealed-trait literal values in
+ *  filter/condition expressions are encoded via [[zio.dynamodb.blocks.schema.DynamoDBCodec]]
+ *  directly, not through a [[zio.blocks.schema.DynamicValue]] round-trip that loses
+ *  the `enumValuesAsStrings` encoding rule.
+ *
+ *  The cross-API proof test (suite 3) demonstrates this concretely: the same item
+ *  with `priority = "High"` (as stored) is found by a [[DdbExprApi]] filter but
+ *  missed by a [[zio.dynamodb.blocks.DdbSchemaExprApi]] filter, which generates
+ *  `priority = {"High": {}}` for the same Scala expression.
+ */
+object DdbExprApiSpec extends DynamoDBLocalSpec {
+
+  // ── Models ───────────────────────────────────────────────────────────────────
+
+  // All-no-field sealed trait: DynamoDBCodecDeriver encodes each case as
+  // AttributeValue.String — e.g. Priority.High → "High".
+  private sealed trait Priority
+  private object Priority {
+    case object Low  extends Priority
+    case object High extends Priority
+    implicit val schema: Schema[Priority] = Schema.derived
+  }
+
+  private case class Task(id: String, priority: Priority)
+  private object Task extends CompanionOptics[Task] {
+    implicit val schema: Schema[Task]  = Schema.derived
+    val id: Lens[Task, String]         = $(_.id)
+    val priority: Lens[Task, Priority] = $(_.priority)
+  }
+
+  // ── Env layer ─────────────────────────────────────────────────────────────────
+
+  private val envLayer: URLayer[DynamoDbAsyncClient, DynamoDBEnv] =
+    ZLayer(ZIO.serviceWith[DynamoDbAsyncClient](client => DynamoDBEnv(client, ZioInterpreter.fromAsyncClient(client))))
+
+  // ── Cross-API helper ──────────────────────────────────────────────────────────
+
+  // Commented out: schema-expr (DdbSchemaExprApi) was removed from the sbt build graph
+  // (deprecated in favor of DdbExprApi). Source kept for reference; not compiled.
+  // Builds a DdbSchemaExprApi scan query in an isolated scope so that its
+  // implicit (SchemaExpr → ConditionExpression) doesn't conflict with the
+  // DdbExprApi implicit (DdbExpr → ConditionExpression) at the call site.
+  // private def schemaExprScan(
+  //   table: String
+  // ): DynamoDBQuery[Task, Page[Either[DynamoDBError.ItemError, Task]]] = {
+  //   import zio.dynamodb.blocks.DdbSchemaExprApi
+  //   import zio.dynamodb.blocks.DdbSchemaExprApi._
+  //   // Task.priority === Priority.High uses ZB's Optic.=== → SchemaExpr[Task, Boolean],
+  //   // which DdbSchemaExprApi implicitly converts to ConditionExpression via DynamicValue.
+  //   // For an all-no-field sealed trait this produces priority = {"High": {}} (wrong).
+  //   DdbSchemaExprApi.scan[Task](table, 10).filter(Task.priority === Priority.High)
+  // }
+
+  // ── Tests ─────────────────────────────────────────────────────────────────────
+
+  // ── Test suites ───────────────────────────────────────────────────────────────
+
+  private val putGetTests: Spec[DynamoDBEnv, Throwable] =
+    suite("put + get round-trip with all-no-field sealed trait")(
+      test("DdbExprApi.get returns Right(Task) with Priority.High decoded correctly") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Task("t1", Priority.High)))
+            result <- interpreter.run(DdbExprApi.get[Task](table)(Task.id.partitionKey === "t1"))
+          } yield assertTrue(result == Right(Task("t1", Priority.High)))
+        }
+      },
+      test("DdbExprApi.get returns Left(ValueNotFound) for absent item") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            result <- interpreter.run(DdbExprApi.get[Task](table)(Task.id.partitionKey === "ghost"))
+          } yield assert(result)(isLeft(isSubtype[DynamoDBError.ItemError.ValueNotFound](anything)))
+        }
+      }
+    )
+
+  private val compoundKeyTests: Spec[DynamoDBEnv, Throwable] =
+    suite("compound partition+sort key")(
+      test("get returns Right(A) with partitionKey + sortKey equality") {
+        final case class Event(id: String, year: String, title: String)
+        object Event extends CompanionOptics[Event] {
+          implicit val schema: Schema[Event] = Schema.derived
+          val id: Lens[Event, String]        = $(_.id)
+          val year: Lens[Event, String]      = $(_.year)
+        }
+
+        withIdAndYearKeyTable { (table, interpreter) =>
+          val event = Event("alice", "2024", "birthday")
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, event))
+            result <- interpreter.run(
+                        DdbExprApi.get[Event](table)(Event.id.partitionKey === "alice" && Event.year.sortKey === "2024")
+                      )
+          } yield assertTrue(result == Right(event))
+        }
+      },
+      test("get returns Left(ValueNotFound) for missing compound key item") {
+        final case class Event(id: String, year: String, title: String)
+        object Event extends CompanionOptics[Event] {
+          implicit val schema: Schema[Event] = Schema.derived
+          val id: Lens[Event, String]        = $(_.id)
+          val year: Lens[Event, String]      = $(_.year)
+        }
+
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            result <- interpreter.run(
+                        DdbExprApi.get[Event](table)(Event.id.partitionKey === "alice" && Event.year.sortKey === "2024")
+                      )
+          } yield assert(result)(isLeft(isSubtype[DynamoDBError.ItemError.ValueNotFound](anything)))
+        }
+      }
+    )
+
+  private val conditionExprTests: Spec[DynamoDBEnv, Throwable] =
+    suite("condition expressions on write operations")(
+      test("put with attributeNotExists succeeds when item is absent") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 42)).where(Score.id.attributeNotExists))
+            result <- interpreter.run(DdbExprApi.get[Score](table)(Score.id.partitionKey === "alice"))
+          } yield assertTrue(result == Right(Score("alice", 42)))
+        }
+      },
+      test("put with attributeNotExists fails when item already exists") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 42)))
+            result <-
+              interpreter.run(DdbExprApi.put(table, Score("alice", 99)).where(Score.id.attributeNotExists)).either
+          } yield assert(result)(isLeft(anything))
+        }
+      },
+      test("put with between condition succeeds when existing value is in range") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+          val score: Lens[Score, Int]        = $(_.score)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 42)))
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 99)).where(Score.score.between(0, 50)))
+            result <- interpreter.run(DdbExprApi.get[Score](table)(Score.id.partitionKey === "alice"))
+          } yield assertTrue(result == Right(Score("alice", 99)))
+        }
+      },
+      test("put with between condition fails when existing value is out of range") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+          val score: Lens[Score, Int]        = $(_.score)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 42)))
+            result <-
+              interpreter.run(DdbExprApi.put(table, Score("alice", 99)).where(Score.score.between(50, 100))).either
+          } yield assert(result)(isLeft(anything))
+        }
+      },
+      test("put with in condition succeeds when existing value matches") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+          val score: Lens[Score, Int]        = $(_.score)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 42)))
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 99)).where(Score.score.in(10, 42, 77)))
+            result <- interpreter.run(DdbExprApi.get[Score](table)(Score.id.partitionKey === "alice"))
+          } yield assertTrue(result == Right(Score("alice", 99)))
+        }
+      }
+    )
+
+  private val enumFilterTests: Spec[DynamoDBEnv, Throwable] =
+    suite("DdbExpr filter — enum literal encoding correctness")(
+      test("scan.filter finds item where priority === Priority.High") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DdbExprApi.put(table, Task("t1", Priority.High)))
+            _    <- interpreter.run(DdbExprApi.put(table, Task("t2", Priority.Low)))
+            page <- interpreter.run(
+                      DdbExprApi
+                        .scan[Task](table, 10)
+                        .filter(Task.priority === Priority.High)
+                    )
+          } yield assertTrue(page.items.collect { case Right(t) => t } == Chunk(Task("t1", Priority.High)))
+        }
+      }
+    )
+
+  // Commented out: depends on schemaExprScan (DdbSchemaExprApi), removed from the sbt
+  // build graph. Source kept for reference; not compiled.
+  // private val crossApiTests: Spec[DynamoDBEnv, Throwable] =
+  //   suite("cross-API encoding mismatch proof")(
+  //     test("DdbExprApi === filter finds item that DdbSchemaExprApi === filter misses") {
+  //       withSingleIdKeyTable { (table, interpreter) =>
+  //         for {
+  //           _          <- interpreter.run(DdbExprApi.put(table, Task("t1", Priority.High)))
+  //           ddbPage    <- interpreter.run(
+  //                           DdbExprApi.scan[Task](table, 10)
+  //                             .filter(Task.priority === Priority.High)
+  //                         )
+  //           schemaPage <- interpreter.run(schemaExprScan(table))
+  //         } yield assertTrue(ddbPage.items.count(_.isRight) == 1) &&
+  //                 assertTrue(schemaPage.items.isEmpty)
+  //       }
+  //     }
+  //   )
+
+  private val queryTests: Spec[DynamoDBEnv, Throwable] =
+    suite("query with DdbKeyExpr key condition")(
+      test("query.whereKey(partitionKey) returns items for that partition key") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DdbExprApi.put(table, Task("t1", Priority.High)))
+            _    <- interpreter.run(DdbExprApi.put(table, Task("t2", Priority.Low)))
+            page <- interpreter.run(
+                      DdbExprApi
+                        .query[Task](table, 10)
+                        .whereKey(Task.id.partitionKey === "t1")
+                    )
+          } yield assertTrue(page.items.collect { case Right(t) => t } == Chunk(Task("t1", Priority.High)))
+        }
+      },
+      test("query with partitionKey + sortKey > filters to range") {
+        final case class Event(id: String, year: String, title: String)
+        object Event extends CompanionOptics[Event] {
+          implicit val schema: Schema[Event] = Schema.derived
+          val id: Lens[Event, String]        = $(_.id)
+          val year: Lens[Event, String]      = $(_.year)
+        }
+
+        withIdAndYearKeyTable { (table, interpreter) =>
+          val events = List(
+            Event("alice", "2021", "a"),
+            Event("alice", "2022", "b"),
+            Event("alice", "2023", "c")
+          )
+          for {
+            _    <- ZIO.foreach(events)(e => interpreter.run(DdbExprApi.put(table, e)))
+            page <- interpreter.run(
+                      DdbExprApi
+                        .query[Event](table, 10)
+                        .whereKey(Event.id.partitionKey === "alice" && Event.year.sortKey > "2021")
+                    )
+            decoded = page.items.collect { case Right(a) => a }
+          } yield assertTrue(decoded.size == 2 && decoded.forall(_.year > "2021"))
+        }
+      },
+      test("query limit caps the page size and returns a non-empty lastEvaluatedKey") {
+        final case class Event(id: String, year: String, title: String)
+        object Event extends CompanionOptics[Event] {
+          implicit val schema: Schema[Event] = Schema.derived
+          val id: Lens[Event, String]        = $(_.id)
+          val year: Lens[Event, String]      = $(_.year)
+        }
+
+        withIdAndYearKeyTable { (table, interpreter) =>
+          val events = List(Event("alice", "2021", "a"), Event("alice", "2022", "b"), Event("alice", "2023", "c"))
+          for {
+            _    <- ZIO.foreach(events)(e => interpreter.run(DdbExprApi.put(table, e)))
+            page <- interpreter.run(
+                      DdbExprApi.query[Event](table, 2).whereKey(Event.id.partitionKey === "alice")
+                    )
+          } yield assertTrue(page.items.size == 2 && page.lastEvaluatedKey.isDefined)
+        }
+      }
+    )
+
+  private val scanTests: Spec[DynamoDBEnv, Throwable] =
+    suite("scan")(
+      test("scan returns all items in the table") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          val items = List(Score("a", 10), Score("b", 20), Score("c", 30))
+          for {
+            _    <- ZIO.foreach(items)(s => interpreter.run(DdbExprApi.put(table, s)))
+            page <- interpreter.run(DdbExprApi.scan[Score](table, 100))
+            decoded = page.items.collect { case Right(a) => a }
+          } yield assertTrue(decoded.toSet == items.toSet && page.lastEvaluatedKey.isEmpty)
+        }
+      },
+      test("scan with filter returns only matching items") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+          val score: Lens[Score, Int]        = $(_.score)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          val items = List(Score("a", 5), Score("b", 15), Score("c", 25))
+          for {
+            _    <- ZIO.foreach(items)(s => interpreter.run(DdbExprApi.put(table, s)))
+            page <- interpreter.run(DdbExprApi.scan[Score](table, 100).filter(Score.score.between(10, 20)))
+            decoded = page.items.collect { case Right(a) => a }
+          } yield assertTrue(decoded.toSet == Set(Score("b", 15)))
+        }
+      }
+    )
+
+  private val updateTests: Spec[DynamoDBEnv, Throwable] =
+    suite("update")(
+      test("update on single partition key table sets field") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+          val score: Lens[Score, Int]        = $(_.score)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 42)))
+            _      <-
+              interpreter.run(DdbExprApi.update[Score](table)(Score.id.partitionKey === "alice")(Score.score.set(100)))
+            result <- interpreter.run(DdbExprApi.get[Score](table)(Score.id.partitionKey === "alice"))
+          } yield assertTrue(result == Right(Score("alice", 100)))
+        }
+      },
+      test("update on compound key table sets field") {
+        final case class Event(id: String, year: String, title: String)
+        object Event extends CompanionOptics[Event] {
+          implicit val schema: Schema[Event] = Schema.derived
+          val id: Lens[Event, String]        = $(_.id)
+          val year: Lens[Event, String]      = $(_.year)
+          val title: Lens[Event, String]     = $(_.title)
+        }
+
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Event("alice", "2024", "birthday")))
+            _      <- interpreter.run(
+                        DdbExprApi.update[Event](table)(Event.id.partitionKey === "alice" && Event.year.sortKey === "2024")(
+                          Event.title.set("anniversary")
+                        )
+                      )
+            result <- interpreter.run(
+                        DdbExprApi.get[Event](table)(Event.id.partitionKey === "alice" && Event.year.sortKey === "2024")
+                      )
+          } yield assertTrue(result == Right(Event("alice", "2024", "anniversary")))
+        }
+      },
+      test("update with condition that holds succeeds") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+          val score: Lens[Score, Int]        = $(_.score)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 42)))
+            _      <- interpreter.run(
+                        DdbExprApi
+                          .update[Score](table)(Score.id.partitionKey === "alice")(Score.score.set(99))
+                          .where(Score.score.between(0, 50) && Score.id.attributeExists)
+                      )
+            result <- interpreter.run(DdbExprApi.get[Score](table)(Score.id.partitionKey === "alice"))
+          } yield assertTrue(result == Right(Score("alice", 99)))
+        }
+      },
+      test("update with condition that fails raises ConditionalCheckFailedException") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+          val score: Lens[Score, Int]        = $(_.score)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 42)))
+            result <- interpreter
+                        .run(
+                          DdbExprApi
+                            .update[Score](table)(Score.id.partitionKey === "alice")(Score.score.set(99))
+                            .where(Score.score.between(50, 100))
+                        )
+                        .either
+          } yield assert(result)(isLeft(isSubtype[ConditionalCheckFailedException](anything)))
+        }
+      }
+    )
+
+  private val deleteTests: Spec[DynamoDBEnv, Throwable] =
+    suite("deleteFrom")(
+      test("deleteFrom on single partition key table removes the item") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 42)))
+            _      <- interpreter.run(DdbExprApi.deleteFrom[Score](table)(Score.id.partitionKey === "alice"))
+            result <- interpreter.run(DdbExprApi.get[Score](table)(Score.id.partitionKey === "alice"))
+          } yield assert(result)(isLeft(isSubtype[DynamoDBError.ItemError.ValueNotFound](anything)))
+        }
+      },
+      test("deleteFrom on compound key table removes the item") {
+        final case class Event(id: String, year: String, title: String)
+        object Event extends CompanionOptics[Event] {
+          implicit val schema: Schema[Event] = Schema.derived
+          val id: Lens[Event, String]        = $(_.id)
+          val year: Lens[Event, String]      = $(_.year)
+        }
+
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Event("alice", "2024", "birthday")))
+            _      <-
+              interpreter.run(
+                DdbExprApi.deleteFrom[Event](table)(Event.id.partitionKey === "alice" && Event.year.sortKey === "2024")
+              )
+            result <- interpreter.run(
+                        DdbExprApi.get[Event](table)(Event.id.partitionKey === "alice" && Event.year.sortKey === "2024")
+                      )
+          } yield assert(result)(isLeft(isSubtype[DynamoDBError.ItemError.ValueNotFound](anything)))
+        }
+      },
+      test("deleteFrom with condition that holds removes the item") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+          val score: Lens[Score, Int]        = $(_.score)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 42)))
+            _      <- interpreter.run(
+                        DdbExprApi
+                          .deleteFrom[Score](table)(Score.id.partitionKey === "alice")
+                          .where(Score.score.between(0, 50) && Score.id.attributeExists)
+                      )
+            result <- interpreter.run(DdbExprApi.get[Score](table)(Score.id.partitionKey === "alice"))
+          } yield assert(result)(isLeft(isSubtype[DynamoDBError.ItemError.ValueNotFound](anything)))
+        }
+      },
+      test("deleteFrom with condition that fails raises ConditionalCheckFailedException") {
+        final case class Score(id: String, score: Int)
+        object Score extends CompanionOptics[Score] {
+          implicit val schema: Schema[Score] = Schema.derived
+          val id: Lens[Score, String]        = $(_.id)
+          val score: Lens[Score, Int]        = $(_.score)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, Score("alice", 42)))
+            result <- interpreter
+                        .run(
+                          DdbExprApi
+                            .deleteFrom[Score](table)(Score.id.partitionKey === "alice")
+                            .where(Score.score.between(50, 100))
+                        )
+                        .either
+          } yield assert(result)(isLeft(isSubtype[ConditionalCheckFailedException](anything)))
+        }
+      }
+    )
+
+  private val nativeSetTests: Spec[DynamoDBEnv, Throwable] =
+    suite("native Set types")(
+      test("Set[String] field round-trips through DynamoDB as StringSet") {
+        final case class Tagged(id: String, tags: Set[String])
+        object Tagged extends CompanionOptics[Tagged] {
+          implicit val schema: Schema[Tagged] = Schema.derived
+          val id: Lens[Tagged, String]        = $(_.id)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          val item = Tagged("t1", Set("alpha", "beta", "gamma"))
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, item))
+            result <- interpreter.run(DdbExprApi.get[Tagged](table)(Tagged.id.partitionKey === "t1"))
+          } yield assertTrue(result == Right(item))
+        }
+      },
+      test("Set[Int] field round-trips through DynamoDB as NumberSet") {
+        final case class Scores(id: String, values: Set[Int])
+        object Scores extends CompanionOptics[Scores] {
+          implicit val schema: Schema[Scores] = Schema.derived
+          val id: Lens[Scores, String]        = $(_.id)
+        }
+
+        withSingleIdKeyTable { (table, interpreter) =>
+          val item = Scores("s1", Set(10, 20, 30))
+          for {
+            _      <- interpreter.run(DdbExprApi.put(table, item))
+            result <- interpreter.run(DdbExprApi.get[Scores](table)(Scores.id.partitionKey === "s1"))
+          } yield assertTrue(result == Right(item))
+        }
+      }
+    )
+
+  def spec =
+    suite("DdbExprApi IT")(
+      putGetTests,
+      compoundKeyTests,
+      conditionExprTests,
+      enumFilterTests,
+      // crossApiTests, // depends on schemaExprScan (DdbSchemaExprApi), commented out above
+      queryTests,
+      scanTests,
+      updateTests,
+      deleteTests,
+      nativeSetTests
+    )
+      .provideSome[DynamoDbAsyncClient](envLayer) @@
+      TestAspect.sequential
+}

--- a/it/src/test/scala/zio/dynamodb/DynamoDBLocalSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/DynamoDBLocalSpec.scala
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2021-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.dynamodb
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+
+import java.time.Duration
+import zio._
+import zio.test.{ TestResult, ZIOSpec }
+
+import java.net.URI
+import java.util.UUID
+
+// Bundles the async client (for admin ops) with a Task-based interpreter (for query ops).
+final case class DynamoDBEnv(asyncClient: DynamoDbAsyncClient, interpreter: Interpreter[Task])
+
+// Starts a DynamoDB Local container once per suite and exposes it as a DynamoDbAsyncClient.
+// Concrete specs extend this, wire an env layer with their chosen interpreter, and call
+// withSingleIdKeyTable / withIdAndYearKeyTable in each test.
+abstract class DynamoDBLocalSpec extends ZIOSpec[DynamoDbAsyncClient] {
+
+  override val bootstrap: ZLayer[Any, Throwable, DynamoDbAsyncClient] =
+    ZLayer.scoped {
+      ZIO
+        .acquireRelease(
+          ZIO.attempt {
+            val container = new GenericContainer(DockerImageName.parse("amazon/dynamodb-local:latest")) {}
+            container.addExposedPort(8000)
+            container.setCommand("-jar", "DynamoDBLocal.jar", "-inMemory", "-sharedDb")
+            container.waitingFor(Wait.forListeningPort())
+            container.start()
+            container
+          }
+        )(c => ZIO.succeed(c.stop()))
+        .map { container =>
+          val endpoint = URI.create(s"http://${container.getHost}:${container.getMappedPort(8000)}")
+          val creds    = StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", "dummy"))
+          // connectionMaxIdleTime(1ms) prevents Netty from reusing connections between
+          // sequential test requests, avoiding the LastHttpContent encoder state bug.
+          DynamoDbAsyncClient
+            .builder()
+            .endpointOverride(endpoint)
+            .credentialsProvider(creds)
+            .region(Region.US_EAST_1)
+            .httpClientBuilder(
+              NettyNioAsyncHttpClient
+                .builder()
+                .connectionMaxIdleTime(Duration.ofMillis(1))
+            )
+            .build()
+        }
+    }
+
+  // -- Table structure definitions -----------------------------------------
+
+  protected def singleIdKeyTable(tableName: String): DynamoDBQuery[Any, Unit] =
+    DynamoDBQuery.createTable(
+      tableName,
+      KeySchema("id"),
+      NonEmptySet(AttributeDefinition.attrDefnString("id")),
+      BillingMode.PayPerRequest
+    )
+
+  protected def idAndYearKeyTable(tableName: String): DynamoDBQuery[Any, Unit] =
+    DynamoDBQuery.createTable(
+      tableName,
+      KeySchema("id", "year"),
+      NonEmptySet(AttributeDefinition.attrDefnString("id"), AttributeDefinition.attrDefnString("year")),
+      BillingMode.PayPerRequest
+    )
+
+  protected def idTableWithCategoryGsi(tableName: String): DynamoDBQuery[Any, Unit] =
+    DynamoDBQuery
+      .createTable(
+        tableName,
+        KeySchema("id"),
+        NonEmptySet(AttributeDefinition.attrDefnString("id"), AttributeDefinition.attrDefnString("category")),
+        BillingMode.PayPerRequest
+      )
+      .gsi("category-index", KeySchema("category"), ProjectionType.All)
+
+  protected def idYearTableWithScoreLsi(tableName: String): DynamoDBQuery[Any, Unit] =
+    DynamoDBQuery
+      .createTable(
+        tableName,
+        KeySchema("id", "year"),
+        NonEmptySet(
+          AttributeDefinition.attrDefnString("id"),
+          AttributeDefinition.attrDefnString("year"),
+          AttributeDefinition.attrDefnString("score")
+        ),
+        BillingMode.PayPerRequest
+      )
+      .lsi("score-index", KeySchema("id", "score"))
+
+  // -- Scoped table lifecycle -----------------------------------------------
+  // Creates a UUID-named table on acquire; deletes it on scope exit regardless of outcome.
+
+  protected def managedTable(
+    tableDefinition: String => DynamoDBQuery[Any, Unit]
+  ): ZIO[DynamoDBEnv & Scope, Throwable, String] =
+    ZIO.acquireRelease(
+      for {
+        env <- ZIO.service[DynamoDBEnv]
+        tableName = s"test-${UUID.randomUUID()}"
+        _   <- env.interpreter.run(tableDefinition(tableName))
+      } yield tableName
+    )(tableName => ZIO.serviceWithZIO[DynamoDBEnv](_.interpreter.run(DynamoDBQuery.deleteTable(tableName))).orDie)
+
+  // -- Convenience wrappers ------------------------------------------------
+
+  protected def withSingleIdKeyTable(
+    f: (String, Interpreter[Task]) => ZIO[Any, Throwable, TestResult]
+  ): ZIO[DynamoDBEnv, Throwable, TestResult] =
+    ZIO.scoped {
+      for {
+        table  <- managedTable(singleIdKeyTable)
+        env    <- ZIO.service[DynamoDBEnv]
+        result <- f(table, env.interpreter)
+      } yield result
+    }
+
+  protected def withIdAndYearKeyTable(
+    f: (String, Interpreter[Task]) => ZIO[Any, Throwable, TestResult]
+  ): ZIO[DynamoDBEnv, Throwable, TestResult] =
+    ZIO.scoped {
+      for {
+        table  <- managedTable(idAndYearKeyTable)
+        env    <- ZIO.service[DynamoDBEnv]
+        result <- f(table, env.interpreter)
+      } yield result
+    }
+
+  protected def withGsiTable(
+    f: (String, Interpreter[Task]) => ZIO[Any, Throwable, TestResult]
+  ): ZIO[DynamoDBEnv, Throwable, TestResult] =
+    ZIO.scoped {
+      for {
+        table  <- managedTable(idTableWithCategoryGsi)
+        env    <- ZIO.service[DynamoDBEnv]
+        result <- f(table, env.interpreter)
+      } yield result
+    }
+
+  protected def withLsiTable(
+    f: (String, Interpreter[Task]) => ZIO[Any, Throwable, TestResult]
+  ): ZIO[DynamoDBEnv, Throwable, TestResult] =
+    ZIO.scoped {
+      for {
+        table  <- managedTable(idYearTableWithScoreLsi)
+        env    <- ZIO.service[DynamoDBEnv]
+        result <- f(table, env.interpreter)
+      } yield result
+    }
+}

--- a/it/src/test/scala/zio/dynamodb/DynamoDBLowLevelApiSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/DynamoDBLowLevelApiSpec.scala
@@ -893,9 +893,12 @@ object DynamoDBLowLevelApiSpec extends DynamoDBLocalSpec {
                        )
                      )
             page1 <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 1))
-            _ = assertTrue(page1.items.length == 1 && page1.lastEvaluatedKey.isDefined)
             page2 <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 10).startKey(page1.lastEvaluatedKey))
-          } yield assertTrue(page1.items.length + page2.items.length == 3)
+          } yield assertTrue(
+            page1.items.length == 1 &&
+              page1.lastEvaluatedKey.isDefined &&
+              page1.items.length + page2.items.length == 3
+          )
         }
       },
       test("scanSome: lastEvaluatedKey is None on the final page") {
@@ -918,14 +921,17 @@ object DynamoDBLowLevelApiSpec extends DynamoDBLocalSpec {
                          .querySome(table, limit = 1)
                          .whereKey($("id").partitionKey === "alice")
                      )
-            _ = assertTrue(page1.items.length == 1 && page1.lastEvaluatedKey.isDefined)
             page2 <- interpreter.run(
                        DynamoDBQuery
                          .querySome(table, limit = 10)
                          .whereKey($("id").partitionKey === "alice")
                          .startKey(page1.lastEvaluatedKey)
                      )
-          } yield assertTrue(page1.items.length + page2.items.length == 3)
+          } yield assertTrue(
+            page1.items.length == 1 &&
+              page1.lastEvaluatedKey.isDefined &&
+              page1.items.length + page2.items.length == 3
+          )
         }
       },
       test("querySome: pages are non-overlapping") {

--- a/it/src/test/scala/zio/dynamodb/DynamoDBLowLevelApiSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/DynamoDBLowLevelApiSpec.scala
@@ -1007,30 +1007,28 @@ object DynamoDBLowLevelApiSpec extends DynamoDBLocalSpec {
           for {
             _      <- interpreter.run(DynamoDBQuery.putItem(table, item))
             result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "types-all")))
-          } yield {
-            val r = result.get
-            assertTrue(
-              result.isDefined &&
-                r.getOption[Boolean]("bool").contains(true) &&
-                r.getOption[Int]("num").contains(42) &&
-                r.getOption[Set[Int]]("numSet").contains(Set(1, 2, 3)) &&
-                r.getOption[String]("str").contains("hello") &&
-                r.getOption[Set[String]]("strSet").contains(Set("x", "y", "z")) &&
-                r.map
-                  .get("list")
-                  .collect { case AttributeValue.List(v) =>
-                    v.collect { case AttributeValue.Number(n) => n.intValue }.toList
-                  }
-                  .contains(List(1, 2, 3)) &&
-                r.getOption[Map[String, Boolean]]("map").contains(Map("a" -> true, "b" -> false)) &&
-                r.map
-                  .get("bin")
-                  .collect { case AttributeValue.Binary(b) =>
-                    b.toList
-                  }
-                  .contains(Chunk.fromArray("abc".getBytes).toList)
-            )
-          }
+          } yield assertTrue(
+            result.exists { r =>
+              r.getOption[Boolean]("bool").contains(true) &&
+              r.getOption[Int]("num").contains(42) &&
+              r.getOption[Set[Int]]("numSet").contains(Set(1, 2, 3)) &&
+              r.getOption[String]("str").contains("hello") &&
+              r.getOption[Set[String]]("strSet").contains(Set("x", "y", "z")) &&
+              r.map
+                .get("list")
+                .collect { case AttributeValue.List(v) =>
+                  v.collect { case AttributeValue.Number(n) => n.intValue }.toList
+                }
+                .contains(List(1, 2, 3)) &&
+              r.getOption[Map[String, Boolean]]("map").contains(Map("a" -> true, "b" -> false)) &&
+              r.map
+                .get("bin")
+                .collect { case AttributeValue.Binary(b) =>
+                  b.toList
+                }
+                .contains(Chunk.fromArray("abc".getBytes).toList)
+            }
+          )
         }
       },
       test("binary set values are preserved after a put/get round-trip") {

--- a/it/src/test/scala/zio/dynamodb/DynamoDBLowLevelApiSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/DynamoDBLowLevelApiSpec.scala
@@ -1,0 +1,1624 @@
+/*
+ * Copyright 2021-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.dynamodb
+
+import cats.effect.unsafe.implicits.{ global => ceRuntime }
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import zio._
+import zio.blocks.chunk.Chunk
+import zio.dynamodb.ProjectionExpression.$
+import zio.test._
+import zio.test.TestAspect
+
+object DynamoDBLowLevelApiSpec extends DynamoDBLocalSpec {
+
+  // Bridges a CE interpreter into Task so the same test suite can run it.
+  private def ceBridge(ceInterp: CEInterpreter): Interpreter[Task] =
+    new Interpreter[Task] {
+      def run[A](q: DynamoDBQuery[_, A]): Task[A] =
+        ZIO.fromFuture(_ => ceInterp.run(q).unsafeToFuture()(ceRuntime))
+    }
+
+  private implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  private val zioEnvLayer: URLayer[DynamoDbAsyncClient, DynamoDBEnv] =
+    ZLayer(ZIO.serviceWith[DynamoDbAsyncClient](client => DynamoDBEnv(client, ZioInterpreter.fromAsyncClient(client))))
+
+  private val ceEnvLayer: URLayer[DynamoDbAsyncClient, DynamoDBEnv] =
+    ZLayer(
+      ZIO.serviceWith[DynamoDbAsyncClient](client =>
+        DynamoDBEnv(client, ceBridge(CEInterpreter.fromAsyncClient(client)))
+      )
+    )
+
+  private def futureBridge(interp: FutureInterpreter): Interpreter[Task] =
+    new Interpreter[Task] {
+      def run[A](q: DynamoDBQuery[_, A]): Task[A] =
+        ZIO.fromFuture(_ => interp.run(q)).mapError {
+          case e: java.util.concurrent.CompletionException if e.getCause != null => e.getCause
+          case e                                                                 => e
+        }
+    }
+
+  private val futureEnvLayer: URLayer[DynamoDbAsyncClient, DynamoDBEnv] =
+    ZLayer(
+      ZIO.serviceWith[DynamoDbAsyncClient](client =>
+        DynamoDBEnv(client, futureBridge(FutureInterpreter.fromAsyncClient(client)))
+      )
+    )
+
+  // ---------------------------------------------------------------------------
+  // Single partition key tests
+  // ---------------------------------------------------------------------------
+
+  private val singleKeyTests: Spec[DynamoDBEnv, Throwable] =
+    suite("single partition key")(
+      test("getItem returns None for a missing key") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          interpreter
+            .run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "missing")))
+            .map(result => assertTrue(result.isEmpty))
+        }
+      },
+      test("putItem then getItem roundtrip") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val item = Item("id" -> "alice", "score" -> 42)
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, item))
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "alice")))
+          } yield assertTrue(result.contains(Item("id" -> "alice", "score" -> 42)))
+        }
+      },
+      test("putItem overwrites an existing item") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "v" -> "first")))
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "v" -> "second")))
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "bob")))
+          } yield assertTrue(result.contains(Item("id" -> "bob", "v" -> "second")))
+        }
+      },
+      test("deleteItem removes an item") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "charlie")))
+            _      <- interpreter.run(DynamoDBQuery.deleteItem(table, PrimaryKey("id" -> "charlie")))
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "charlie")))
+          } yield assertTrue(result.isEmpty)
+        }
+      },
+      test("scanSome returns all inserted items") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "a")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "b")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "c")))
+            page <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 10))
+          } yield assertTrue(page.items.length == 3)
+        }
+      },
+      test("createTable/describeTable/deleteTable lifecycle") {
+        for {
+          env  <- ZIO.service[DynamoDBEnv]
+          tableName = s"lifecycle-${java.util.UUID.randomUUID()}"
+          attrs = NonEmptySet(AttributeDefinition.attrDefnString("id"))
+          _    <-
+            env.interpreter.run(DynamoDBQuery.createTable(tableName, KeySchema("id"), attrs, BillingMode.PayPerRequest))
+          desc <- env.interpreter.run(DynamoDBQuery.describeTable(tableName))
+          _    <- env.interpreter.run(DynamoDBQuery.deleteTable(tableName))
+        } yield assertTrue(desc.tableStatus == DynamoDBQuery.TableStatus.Active)
+      },
+      test("zipped gets execute independently") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "x")))
+            q = DynamoDBQuery.getItem(table, PrimaryKey("id" -> "x")) zipPar
+                  DynamoDBQuery.getItem(table, PrimaryKey("id" -> "y"))
+            pair <- interpreter.run(q)
+            (rx, ry) = pair
+          } yield assertTrue(rx.isDefined && ry.isEmpty)
+        }
+      },
+      test("zipPar getItem results are returned in a tuple with correct values") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "score" -> 10)))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "score" -> 20)))
+            q = DynamoDBQuery.getItem(table, PrimaryKey("id" -> "alice")) zipPar
+                  DynamoDBQuery.getItem(table, PrimaryKey("id" -> "bob"))
+            pair <- interpreter.run(q)
+            (ra, rb) = pair
+          } yield assertTrue(
+            ra.flatMap(_.getOption[Int]("score")).contains(10) &&
+              rb.flatMap(_.getOption[Int]("score")).contains(20)
+          )
+        }
+      },
+      test("zipPar three queries returns a 3-tuple with correct values") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "c1", "v" -> 1)))
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "c2", "v" -> 2)))
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "c3", "v" -> 3)))
+            q = DynamoDBQuery.getItem(table, PrimaryKey("id" -> "c1")) zipPar
+                  DynamoDBQuery.getItem(table, PrimaryKey("id" -> "c2")) zipPar
+                  DynamoDBQuery.getItem(table, PrimaryKey("id" -> "c3"))
+            triple <- interpreter.run(q)
+            (r1, r2, r3) = triple
+          } yield assertTrue(
+            r1.flatMap(_.getOption[Int]("v")).contains(1) &&
+              r2.flatMap(_.getOption[Int]("v")).contains(2) &&
+              r3.flatMap(_.getOption[Int]("v")).contains(3)
+          )
+        }
+      },
+      test("getItem with projection returns only requested attributes") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val item = Item("id" -> "proj-alice", "score" -> 42, "extra" -> "excluded")
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, item))
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "proj-alice"), $("score")))
+          } yield assertTrue(
+            result.exists(_.map.contains("score")) &&
+              result.map(_.map.contains("extra")).exists(!_)
+          )
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // Composite partition+sort key tests (id + year)
+  // ---------------------------------------------------------------------------
+
+  private val compositeKeyTests: Spec[DynamoDBEnv, Throwable] =
+    suite("composite partition+sort key")(
+      test("getItem returns None for a missing composite key") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          interpreter
+            .run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "missing", "year" -> "2024")))
+            .map(result => assertTrue(result.isEmpty))
+        }
+      },
+      test("putItem then getItem roundtrip with composite key") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          val item = Item("id" -> "alice", "year" -> "2024", "score" -> 42)
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, item))
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "alice", "year" -> "2024")))
+          } yield assertTrue(result.contains(Item("id" -> "alice", "year" -> "2024", "score" -> 42)))
+        }
+      },
+      test("same partition key with different sort keys produces distinct items") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _     <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2023", "score" -> 10)))
+            _     <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2024", "score" -> 20)))
+            r2023 <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "alice", "year" -> "2023")))
+            r2024 <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "alice", "year" -> "2024")))
+          } yield assertTrue(
+            r2023.contains(Item("id" -> "alice", "year" -> "2023", "score" -> 10)) &&
+              r2024.contains(Item("id" -> "alice", "year" -> "2024", "score" -> 20))
+          )
+        }
+      },
+      test("putItem overwrites item with same composite key") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "year" -> "2024", "v" -> "first")))
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "year" -> "2024", "v" -> "second")))
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "bob", "year" -> "2024")))
+          } yield assertTrue(result.contains(Item("id" -> "bob", "year" -> "2024", "v" -> "second")))
+        }
+      },
+      test("deleteItem removes only the targeted sort key, leaving sibling intact") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _       <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "charlie", "year" -> "2023")))
+            _       <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "charlie", "year" -> "2024")))
+            _       <- interpreter.run(DynamoDBQuery.deleteItem(table, PrimaryKey("id" -> "charlie", "year" -> "2023")))
+            deleted <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "charlie", "year" -> "2023")))
+            intact  <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "charlie", "year" -> "2024")))
+          } yield assertTrue(deleted.isEmpty && intact.isDefined)
+        }
+      },
+      test("scanSome returns all items across different partition and sort keys") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "a", "year" -> "2022")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "a", "year" -> "2023")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "b", "year" -> "2022")))
+            page <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 10))
+          } yield assertTrue(page.items.length == 3)
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // Batch write tests
+  // ---------------------------------------------------------------------------
+
+  private val batchingTests: Spec[DynamoDBEnv, Throwable] =
+    suite("batchWriteItem")(
+      test("batch put — all items readable after write") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val items = List(
+            Item("id" -> "a", "v" -> 1),
+            Item("id" -> "b", "v" -> 2),
+            Item("id" -> "c", "v" -> 3)
+          )
+          for {
+            _  <- interpreter.run(DynamoDBQuery.batchWriteItem(items)(item => DynamoDBQuery.putItem(table, item)))
+            ra <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "a")))
+            rb <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "b")))
+            rc <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "c")))
+          } yield assertTrue(
+            ra.contains(Item("id" -> "a", "v" -> 1)) &&
+              rb.contains(Item("id" -> "b", "v" -> 2)) &&
+              rc.contains(Item("id" -> "c", "v" -> 3))
+          )
+        }
+      },
+      test("batch delete — items absent after sequential put then delete batch") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val items = List(Item("id" -> "x"), Item("id" -> "y"))
+          val keys  = List(PrimaryKey("id" -> "x"), PrimaryKey("id" -> "y"))
+          for {
+            _  <- interpreter.run(DynamoDBQuery.batchWriteItem(items)(item => DynamoDBQuery.putItem(table, item)))
+            _  <- interpreter.run(DynamoDBQuery.batchWriteItem(keys)(key => DynamoDBQuery.deleteItem(table, key)))
+            rx <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "x")))
+            ry <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "y")))
+          } yield assertTrue(rx.isEmpty && ry.isEmpty)
+        }
+      },
+      test("mixed puts and deletes in one batch") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val writes: List[Either[Item, PrimaryKey]] = List(
+            Left(Item("id" -> "keep-me", "v" -> 42)),
+            Right(PrimaryKey("id" -> "del-me"))
+          )
+          for {
+            _       <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "del-me")))
+            _       <- interpreter.run(DynamoDBQuery.batchWriteItem(writes) {
+                         case Left(item) => DynamoDBQuery.putItem(table, item)
+                         case Right(key) => DynamoDBQuery.deleteItem(table, key)
+                       })
+            kept    <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "keep-me")))
+            deleted <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "del-me")))
+          } yield assertTrue(kept.contains(Item("id" -> "keep-me", "v" -> 42)) && deleted.isEmpty)
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // Batch get tests
+  // ---------------------------------------------------------------------------
+
+  private val batchGetItemTests: Spec[DynamoDBEnv, Throwable] =
+    suite("batchGetItem")(
+      test("batch get returns all items that were put") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val items = List(
+            Item("id" -> "a", "v" -> 1),
+            Item("id" -> "b", "v" -> 2),
+            Item("id" -> "c", "v" -> 3)
+          )
+          val batch =
+            DynamoDBQuery.batchGetItem(List("a", "b", "c"))(id => DynamoDBQuery.getItem(table, PrimaryKey("id" -> id)))
+          for {
+            _        <- interpreter.run(DynamoDBQuery.batchWriteItem(items)(item => DynamoDBQuery.putItem(table, item)))
+            response <- interpreter.run(batch)
+            results = batch.toGetItemResponses(response)
+          } yield assertTrue(
+            results.length == 3 &&
+              results.forall(_.isDefined)
+          )
+        }
+      },
+      test("batch get returns None for keys that do not exist") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val batch = DynamoDBQuery.batchGetItem(List("missing-1", "missing-2"))(id =>
+            DynamoDBQuery.getItem(table, PrimaryKey("id" -> id))
+          )
+          for {
+            response <- interpreter.run(batch)
+            results = batch.toGetItemResponses(response)
+          } yield assertTrue(results.length == 2 && results.forall(_.isEmpty))
+        }
+      },
+      test("batch get mixed — present key resolves to Some, absent key resolves to None") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val batch = DynamoDBQuery.batchGetItem(List("present", "absent"))(id =>
+            DynamoDBQuery.getItem(table, PrimaryKey("id" -> id))
+          )
+          for {
+            _        <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "present", "v" -> 42)))
+            response <- interpreter.run(batch)
+            results = batch.toGetItemResponses(response)
+          } yield assertTrue(
+            results.length == 2 &&
+              results(0).isDefined &&
+              results(1).isEmpty
+          )
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // UpdateItem tests
+  // ---------------------------------------------------------------------------
+
+  private val updateItemTests: Spec[DynamoDBEnv, Throwable] =
+    suite("updateItem")(
+      test("set overwrites an existing attribute") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "score" -> 0)))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "alice")) {
+                          $("score").set(42)
+                        }
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "alice")))
+          } yield assertTrue(result.contains(Item("id" -> "alice", "score" -> 42)))
+        }
+      },
+      test("set adds a new attribute to an existing item") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob")))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "bob")) {
+                          $("score").set(99)
+                        }
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "bob")))
+          } yield assertTrue(result.contains(Item("id" -> "bob", "score" -> 99)))
+        }
+      },
+      test("update with condition succeeds when condition matches") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "charlie", "score" -> 0)))
+            _      <- interpreter.run(
+                        DynamoDBQuery
+                          .updateItem(table, PrimaryKey("id" -> "charlie")) {
+                            $("score").set(42)
+                          }
+                          .where($("score") === 0)
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "charlie")))
+          } yield assertTrue(result.contains(Item("id" -> "charlie", "score" -> 42)))
+        }
+      },
+      test("update with condition fails when condition does not match — item unchanged") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "dave", "score" -> 0)))
+            result <- interpreter
+                        .run(
+                          DynamoDBQuery
+                            .updateItem(table, PrimaryKey("id" -> "dave")) {
+                              $("score").set(99)
+                            }
+                            .where($("score") === 100)
+                        )
+                        .either
+            item   <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "dave")))
+          } yield assertTrue(result.isLeft && item.contains(Item("id" -> "dave", "score" -> 0)))
+        }
+      },
+      test("remove deletes an attribute from an item") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "eve", "score" -> 42, "tmp" -> "x")))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "eve")) {
+                          UpdateExpression.Action.RemoveAction($("tmp"))
+                        }
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "eve")))
+          } yield assertTrue(result.contains(Item("id" -> "eve", "score" -> 42)))
+        }
+      },
+      test("zipPar runs two updates to different rows concurrently") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _  <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "par-a", "score" -> 0)))
+            _  <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "par-b", "score" -> 0)))
+            q = DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "par-a"))($("score").set(1)) zipPar
+                  DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "par-b"))($("score").set(2))
+            _  <- interpreter.run(q)
+            ra <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "par-a")))
+            rb <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "par-b")))
+          } yield assertTrue(
+            ra.contains(Item("id" -> "par-a", "score" -> 1)) &&
+              rb.contains(Item("id" -> "par-b", "score" -> 2))
+          )
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // Condition expression (where) and filter expression (filter) tests
+  // ---------------------------------------------------------------------------
+
+  private val conditionAndFilterTests: Spec[DynamoDBEnv, Throwable] =
+    suite("condition and filter expressions")(
+      suite("where on putItem")(
+        test("put succeeds when condition matches existing attribute value") {
+          withSingleIdKeyTable { (table, interpreter) =>
+            for {
+              _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "score" -> 0)))
+              _      <- interpreter.run(
+                          DynamoDBQuery
+                            .putItem(table, Item("id" -> "alice", "score" -> 1))
+                            .where($("score") === 0)
+                        )
+              result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "alice")))
+            } yield assertTrue(result.contains(Item("id" -> "alice", "score" -> 1)))
+          }
+        },
+        test("put fails when condition does not match — item remains unchanged") {
+          withSingleIdKeyTable { (table, interpreter) =>
+            for {
+              _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "score" -> 0)))
+              result <- interpreter
+                          .run(
+                            DynamoDBQuery
+                              .putItem(table, Item("id" -> "bob", "score" -> 99))
+                              .where($("score") === 42)
+                          )
+                          .either
+              item   <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "bob")))
+            } yield assertTrue(result.isLeft && item.contains(Item("id" -> "bob", "score" -> 0)))
+          }
+        }
+      ),
+      suite("where on deleteItem")(
+        test("delete succeeds when condition matches") {
+          withSingleIdKeyTable { (table, interpreter) =>
+            for {
+              _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "charlie", "score" -> 42)))
+              _      <- interpreter.run(
+                          DynamoDBQuery
+                            .deleteItem(table, PrimaryKey("id" -> "charlie"))
+                            .where($("score") === 42)
+                        )
+              result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "charlie")))
+            } yield assertTrue(result.isEmpty)
+          }
+        },
+        test("delete fails when condition does not match — item survives") {
+          withSingleIdKeyTable { (table, interpreter) =>
+            for {
+              _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "dave", "score" -> 42)))
+              fail <- interpreter
+                        .run(
+                          DynamoDBQuery
+                            .deleteItem(table, PrimaryKey("id" -> "dave"))
+                            .where($("score") === 0)
+                        )
+                        .either
+              item <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "dave")))
+            } yield assertTrue(fail.isLeft && item.isDefined)
+          }
+        }
+      ),
+      suite("filter on scanSome")(
+        test("scan returns only items matching the filter") {
+          withSingleIdKeyTable { (table, interpreter) =>
+            for {
+              _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "s1", "score" -> 1)))
+              _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "s5", "score" -> 5)))
+              _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "s10", "score" -> 10)))
+              page <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 10).filter($("score") > 5))
+            } yield assertTrue(page.items.length == 1)
+          }
+        },
+        test("scan with filter that matches nothing returns empty page") {
+          withSingleIdKeyTable { (table, interpreter) =>
+            for {
+              _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "t1", "score" -> 1)))
+              _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "t5", "score" -> 5)))
+              page <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 10).filter($("score") > 100))
+            } yield assertTrue(page.items.isEmpty)
+          }
+        }
+      )
+    )
+
+  // ---------------------------------------------------------------------------
+  // querySome tests using whereKey and PE syntax
+  // ---------------------------------------------------------------------------
+
+  private val querySomeTests: Spec[DynamoDBEnv, Throwable] =
+    suite("querySome with whereKey")(
+      test("partition key only returns all items for that partition key") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2022")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2023")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2024")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "year" -> "2024")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "alice")
+                    )
+          } yield assertTrue(page.items.length == 3)
+        }
+      },
+      test("composite equality returns exact item") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2022")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2023")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2024")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "alice" && $("year").sortKey === "2023")
+                    )
+          } yield assertTrue(
+            page.items.length == 1 &&
+              page.items.head == Item("id" -> "alice", "year" -> "2023")
+          )
+        }
+      },
+      test("sort key > returns items with sk greater than given value") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2021")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2022")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2023")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2024")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "alice" && $("year").sortKey > "2022")
+                    )
+          } yield assertTrue(page.items.length == 2)
+        }
+      },
+      test("sort key beginsWith returns only matching items") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2022-Q1")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2022-Q2")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2023-Q1")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "alice" && $("year").sortKey.beginsWith("2022"))
+                    )
+          } yield assertTrue(page.items.length == 2)
+        }
+      },
+      test("querySome with whereKey and filter expression") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2022", "score" -> 5)))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2023", "score" -> 50)))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2024", "score" -> 100)))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "alice")
+                        .filter($("score") > 10)
+                    )
+          } yield assertTrue(page.items.length == 2)
+        }
+      },
+      test("sortOrder(ascending = false) returns items in descending sort-key order") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2021")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2022")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2023")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "alice")
+                        .sortOrder(ascending = false)
+                    )
+          } yield assertTrue(
+            page.items.map(_.map.get("year")).toList ==
+              List(
+                Some(AttributeValue.String("2023")),
+                Some(AttributeValue.String("2022")),
+                Some(AttributeValue.String("2021"))
+              )
+          )
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // capacity() builder — smoke tests (verifies the full path doesn't break ops)
+  // ---------------------------------------------------------------------------
+
+  private val capacityTests: Spec[DynamoDBEnv, Throwable] =
+    suite("capacity builder")(
+      test("getItem with capacity(Total) still returns the correct item") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "cap-a", "v" -> 1)))
+            result <- interpreter.run(
+                        DynamoDBQuery
+                          .getItem(table, PrimaryKey("id" -> "cap-a"))
+                          .capacity(ReturnConsumedCapacity.Total)
+                      )
+          } yield assertTrue(result.contains(Item("id" -> "cap-a", "v" -> 1)))
+        }
+      },
+      test("putItem with capacity(Total) succeeds") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(
+                        DynamoDBQuery
+                          .putItem(table, Item("id" -> "cap-b"))
+                          .capacity(ReturnConsumedCapacity.Total)
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "cap-b")))
+          } yield assertTrue(result.isDefined)
+        }
+      },
+      test("scanSome with capacity(Total) returns items") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "cap-s1")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "cap-s2")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .scanSome(table, limit = 10)
+                        .capacity(ReturnConsumedCapacity.Total)
+                    )
+          } yield assertTrue(page.items.length == 2)
+        }
+      },
+      test("batchGetItem with capacity(Total) returns all items") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val items = List(Item("id" -> "cap-g1", "v" -> 1), Item("id" -> "cap-g2", "v" -> 2))
+          val batch = DynamoDBQuery
+            .batchGetItem(List("cap-g1", "cap-g2"))(id => DynamoDBQuery.getItem(table, PrimaryKey("id" -> id)))
+            .capacity(ReturnConsumedCapacity.Total)
+          for {
+            _        <- interpreter.run(DynamoDBQuery.batchWriteItem(items)(i => DynamoDBQuery.putItem(table, i)))
+            response <- interpreter.run(batch.asInstanceOf[DynamoDBQuery.BatchGetItem])
+            results = batch.asInstanceOf[DynamoDBQuery.BatchGetItem].toGetItemResponses(response)
+          } yield assertTrue(results.length == 2 && results.forall(_.isDefined))
+        }
+      }
+    )
+
+  private val consistencyTests: Spec[DynamoDBEnv, Throwable] =
+    suite("consistency builder")(
+      test("getItem with consistency(Strong) still returns the correct item") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "con-a", "v" -> 1)))
+            result <- interpreter.run(
+                        DynamoDBQuery
+                          .getItem(table, PrimaryKey("id" -> "con-a"))
+                          .consistency(ConsistencyMode.Strong)
+                      )
+          } yield assertTrue(result.contains(Item("id" -> "con-a", "v" -> 1)))
+        }
+      },
+      test("scanSome with consistency(Strong) returns items") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "con-s1")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .scanSome(table, limit = 10)
+                        .consistency(ConsistencyMode.Strong)
+                    )
+          } yield assertTrue(page.items.nonEmpty)
+        }
+      }
+    )
+
+  private val returnsTests: Spec[DynamoDBEnv, Throwable] =
+    suite("returns builder")(
+      test("putItem with returns(AllOld) succeeds and returns old item") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "ret-a", "v" -> 1)))
+            result <- interpreter.run(
+                        DynamoDBQuery
+                          .putItem(table, Item("id" -> "ret-a", "v" -> 2))
+                          .returns(ReturnValues.AllOld)
+                      )
+          } yield assertTrue(result.contains(Item("id" -> "ret-a", "v" -> 1)))
+        }
+      },
+      test("deleteItem with returns(AllOld) returns the deleted item") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "ret-d", "v" -> 99)))
+            result <- interpreter.run(
+                        DynamoDBQuery
+                          .deleteItem(table, PrimaryKey("id" -> "ret-d"))
+                          .returns(ReturnValues.AllOld)
+                      )
+          } yield assertTrue(result.contains(Item("id" -> "ret-d", "v" -> 99)))
+        }
+      }
+    )
+
+  private val selectTests: Spec[DynamoDBEnv, Throwable] =
+    suite("select and Page.count / Page.scannedCount")(
+      test("Page.count equals items.size on a normal scan") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "a")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "b")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "c")))
+            page <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 10))
+          } yield assertTrue(page.count == page.items.size && page.count == 3)
+        }
+      },
+      test("Page.scannedCount equals count when no filter is applied") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "x")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "y")))
+            page <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 10))
+          } yield assertTrue(page.scannedCount == page.count)
+        }
+      },
+      test("Page.scannedCount > count when a filter reduces the result set") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "s1", "v" -> 1)))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "s2", "v" -> 2)))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "s3", "v" -> 3)))
+            page <- interpreter.run(
+                      DynamoDBQuery.scanSome(table, limit = 10).filter($("v") > 1)
+                    )
+          } yield assertTrue(page.scannedCount == 3 && page.count == 2)
+        }
+      },
+      test("selectCount: items is empty and count reflects matching items") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "c1")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "c2")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "c3")))
+            page <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 10).selectCount)
+          } yield assertTrue(page.items.isEmpty && page.count == 3)
+        }
+      },
+      test("querySome selectCount: count reflects matching items for a partition key") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2021")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2022")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "year" -> "2021")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "alice")
+                        .selectCount
+                    )
+          } yield assertTrue(page.items.isEmpty && page.count == 2)
+        }
+      }
+    )
+
+  private val gsiTests: Spec[DynamoDBEnv, Throwable] =
+    suite("gsi builder")(
+      test("querySome on a GSI returns only items matching the GSI partition key") {
+        withGsiTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "a", "category" -> "fruit")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "b", "category" -> "vegetable")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "c", "category" -> "fruit")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10, indexName = Some("category-index"))
+                        .whereKey($("category").partitionKey === "fruit")
+                    )
+          } yield assertTrue(page.items.length == 2)
+        }
+      },
+      test("querySome on a GSI returns no items when partition key has no matches") {
+        withGsiTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "a", "category" -> "fruit")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10, indexName = Some("category-index"))
+                        .whereKey($("category").partitionKey === "mineral")
+                    )
+          } yield assertTrue(page.items.isEmpty)
+        }
+      }
+    )
+
+  private val lsiTests: Spec[DynamoDBEnv, Throwable] =
+    suite("lsi builder")(
+      test("querySome on an LSI returns items ordered by the LSI sort key") {
+        withLsiTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2024", "score" -> "b")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2023", "score" -> "a")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2022", "score" -> "c")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10, indexName = Some("score-index"))
+                        .whereKey($("id").partitionKey === "alice")
+                    )
+          } yield assertTrue(page.items.length == 3)
+        }
+      },
+      test("querySome on an LSI with sort key condition returns matching items only") {
+        withLsiTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "year" -> "2024", "score" -> "z")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "year" -> "2023", "score" -> "a")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10, indexName = Some("score-index"))
+                        .whereKey($("id").partitionKey === "bob" && $("score").sortKey === "z")
+                    )
+          } yield assertTrue(page.items.length == 1)
+        }
+      }
+    )
+
+  private val startKeyTests: Spec[DynamoDBEnv, Throwable] =
+    suite("startKey paging")(
+      test("scanSome: second page starts after the last key of the first page") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _     <- interpreter.run(
+                       DynamoDBQuery.batchWriteItem(List("sk-1", "sk-2", "sk-3"))(id =>
+                         DynamoDBQuery.putItem(table, Item("id" -> id))
+                       )
+                     )
+            page1 <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 1))
+            _ = assertTrue(page1.items.length == 1 && page1.lastEvaluatedKey.isDefined)
+            page2 <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 10).startKey(page1.lastEvaluatedKey))
+          } yield assertTrue(page1.items.length + page2.items.length == 3)
+        }
+      },
+      test("scanSome: lastEvaluatedKey is None on the final page") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _     <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "only")))
+            page1 <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 1))
+            page2 <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 10).startKey(page1.lastEvaluatedKey))
+          } yield assertTrue(page2.items.isEmpty && page2.lastEvaluatedKey.isEmpty)
+        }
+      },
+      test("querySome: second page starts after the last key of the first page") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _     <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2021")))
+            _     <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2022")))
+            _     <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2023")))
+            page1 <- interpreter.run(
+                       DynamoDBQuery
+                         .querySome(table, limit = 1)
+                         .whereKey($("id").partitionKey === "alice")
+                     )
+            _ = assertTrue(page1.items.length == 1 && page1.lastEvaluatedKey.isDefined)
+            page2 <- interpreter.run(
+                       DynamoDBQuery
+                         .querySome(table, limit = 10)
+                         .whereKey($("id").partitionKey === "alice")
+                         .startKey(page1.lastEvaluatedKey)
+                     )
+          } yield assertTrue(page1.items.length + page2.items.length == 3)
+        }
+      },
+      test("querySome: pages are non-overlapping") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _     <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "year" -> "2021")))
+            _     <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "year" -> "2022")))
+            _     <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bob", "year" -> "2023")))
+            page1 <- interpreter.run(
+                       DynamoDBQuery
+                         .querySome(table, limit = 2)
+                         .whereKey($("id").partitionKey === "bob")
+                     )
+            page2 <- interpreter.run(
+                       DynamoDBQuery
+                         .querySome(table, limit = 2)
+                         .whereKey($("id").partitionKey === "bob")
+                         .startKey(page1.lastEvaluatedKey)
+                     )
+            allItems = (page1.items ++ page2.items).map(_.getOption[String]("year"))
+          } yield assertTrue(
+            page1.items.length == 2 &&
+              page2.items.length == 1 &&
+              allItems.toSet.size == 3
+          )
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // Parallel scan segments
+  // ---------------------------------------------------------------------------
+
+  private val segmentTests: Spec[DynamoDBEnv, Throwable] =
+    suite("parallel scan segments")(
+      test("two segments together cover all items with no overlaps") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val ids = List("seg-1", "seg-2", "seg-3", "seg-4", "seg-5", "seg-6")
+          for {
+            _    <- interpreter.run(
+                      DynamoDBQuery.batchWriteItem(ids)(id => DynamoDBQuery.putItem(table, Item("id" -> id)))
+                    )
+            seg0 <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 100).segment(0, 2))
+            seg1 <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 100).segment(1, 2))
+            allIds = (seg0.items ++ seg1.items).flatMap(_.getOption[String]("id")).toSet
+          } yield assertTrue(
+            allIds == ids.toSet &&
+              seg0.items.length + seg1.items.length == ids.length
+          )
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // All DynamoDB attribute types
+  // ---------------------------------------------------------------------------
+
+  private val allAttributeTypesTests: Spec[DynamoDBEnv, Throwable] =
+    suite("all attribute types")(
+      test("scalar and collection types survive a put/get round-trip") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val item = Item(
+            "id"     -> "types-all",
+            "bin"    -> Chunk.fromArray("abc".getBytes),
+            "bool"   -> true,
+            "list"   -> List(1, 2, 3),
+            "map"    -> Map("a" -> true, "b" -> false),
+            "num"    -> 42,
+            "numSet" -> Set(1, 2, 3),
+            "str"    -> "hello",
+            "strSet" -> Set("x", "y", "z")
+          )
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, item))
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "types-all")))
+          } yield {
+            val r = result.get
+            assertTrue(
+              result.isDefined &&
+                r.getOption[Boolean]("bool").contains(true) &&
+                r.getOption[Int]("num").contains(42) &&
+                r.getOption[Set[Int]]("numSet").contains(Set(1, 2, 3)) &&
+                r.getOption[String]("str").contains("hello") &&
+                r.getOption[Set[String]]("strSet").contains(Set("x", "y", "z")) &&
+                r.map
+                  .get("list")
+                  .collect { case AttributeValue.List(v) =>
+                    v.collect { case AttributeValue.Number(n) => n.intValue }.toList
+                  }
+                  .contains(List(1, 2, 3)) &&
+                r.getOption[Map[String, Boolean]]("map").contains(Map("a" -> true, "b" -> false)) &&
+                r.map
+                  .get("bin")
+                  .collect { case AttributeValue.Binary(b) =>
+                    b.toList
+                  }
+                  .contains(Chunk.fromArray("abc".getBytes).toList)
+            )
+          }
+        }
+      },
+      test("binary set values are preserved after a put/get round-trip") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val bytes = Chunk.fromArray("hello".getBytes)
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bs-test", "bs" -> Set(bytes))))
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "bs-test")))
+          } yield {
+            val preserved = result.flatMap(_.map.get("bs")).collect { case AttributeValue.BinarySet(v) =>
+              v.map(_.toList).toSet
+            }
+            assertTrue(preserved.contains(Set(bytes.toList)))
+          }
+        }
+      },
+      test("null attribute is stored and retrieved") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val item = Item("id" -> "null-test", "nf" -> (AttributeValue.Null: AttributeValue))
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, item))
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "null-test")))
+          } yield assertTrue(result.contains(item))
+        }
+      },
+      test("empty Set is not stored as an attribute") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(
+                        DynamoDBQuery.putItem(table, Item("id" -> "empty-set", "es" -> Set.empty[Int]))
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "empty-set")))
+          } yield assertTrue(result.flatMap(_.map.get("es")).isEmpty)
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // updateItem return values (UpdatedOld / AllOld / AllNew / UpdatedNew)
+  // ---------------------------------------------------------------------------
+
+  private val updateReturnValuesExtendedTests: Spec[DynamoDBEnv, Throwable] =
+    suite("updateItem return values")(
+      test("UpdatedOld returns only the changed attributes with their old values") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(
+                        DynamoDBQuery.putItem(table, Item("id" -> "rv-a", "score" -> 0, "name" -> "alice"))
+                      )
+            result <- interpreter.run(
+                        DynamoDBQuery
+                          .updateItem(table, PrimaryKey("id" -> "rv-a"))($("score").set(42))
+                          .returns(ReturnValues.UpdatedOld)
+                      )
+          } yield assertTrue(result.contains(Item("score" -> 0)))
+        }
+      },
+      test("AllOld returns the entire item with its values before the update") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val original = Item("id" -> "rv-b", "score" -> 0, "name" -> "bob")
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, original))
+            result <- interpreter.run(
+                        DynamoDBQuery
+                          .updateItem(table, PrimaryKey("id" -> "rv-b"))($("score").set(99))
+                          .returns(ReturnValues.AllOld)
+                      )
+          } yield assertTrue(result.contains(original))
+        }
+      },
+      test("AllNew returns the entire item with its values after the update") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(
+                        DynamoDBQuery.putItem(table, Item("id" -> "rv-c", "score" -> 0, "name" -> "charlie"))
+                      )
+            result <- interpreter.run(
+                        DynamoDBQuery
+                          .updateItem(table, PrimaryKey("id" -> "rv-c"))($("score").set(42))
+                          .returns(ReturnValues.AllNew)
+                      )
+          } yield assertTrue(result.contains(Item("id" -> "rv-c", "score" -> 42, "name" -> "charlie")))
+        }
+      },
+      test("UpdatedNew returns only the changed attributes with their new values") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(
+                        DynamoDBQuery.putItem(table, Item("id" -> "rv-d", "score" -> 0, "name" -> "dave"))
+                      )
+            result <- interpreter.run(
+                        DynamoDBQuery
+                          .updateItem(table, PrimaryKey("id" -> "rv-d"))($("score").set(42))
+                          .returns(ReturnValues.UpdatedNew)
+                      )
+          } yield assertTrue(result.contains(Item("score" -> 42)))
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // updateItem arithmetic and setIfNotExists
+  // ---------------------------------------------------------------------------
+
+  private val updateArithmeticTests: Spec[DynamoDBEnv, Throwable] =
+    suite("updateItem arithmetic and setIfNotExists")(
+      test("SetAction with + increments a numeric attribute") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "arith-a", "n" -> 0)))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "arith-a")) {
+                          UpdateExpression.Action.SetAction(
+                            $("n"),
+                            UpdateExpression.SetOperand.PathOperand($("n")) +
+                              UpdateExpression.SetOperand.ValueOperand(AttributeValue.Number(5))
+                          )
+                        }
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "arith-a")))
+          } yield assertTrue(result.contains(Item("id" -> "arith-a", "n" -> 5)))
+        }
+      },
+      test("SetAction with - decrements a numeric attribute") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "arith-b", "n" -> 10)))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "arith-b")) {
+                          UpdateExpression.Action.SetAction(
+                            $("n"),
+                            UpdateExpression.SetOperand.PathOperand($("n")) -
+                              UpdateExpression.SetOperand.ValueOperand(AttributeValue.Number(3))
+                          )
+                        }
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "arith-b")))
+          } yield assertTrue(result.contains(Item("id" -> "arith-b", "n" -> 7)))
+        }
+      },
+      test("add action increments a numeric attribute") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "arith-c", "n" -> 42)))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "arith-c"))($("n").add(8))
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "arith-c")))
+          } yield assertTrue(result.contains(Item("id" -> "arith-c", "n" -> 50)))
+        }
+      },
+      test("setIfNotExists sets the attribute when absent") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "ifne-a")))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "ifne-a")) {
+                          $("score").setIfNotExists(99)
+                        }
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "ifne-a")))
+          } yield assertTrue(result.contains(Item("id" -> "ifne-a", "score" -> 99)))
+        }
+      },
+      test("setIfNotExists leaves the attribute unchanged when already present") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "ifne-b", "score" -> 0)))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "ifne-b")) {
+                          $("score").setIfNotExists(99)
+                        }
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "ifne-b")))
+          } yield assertTrue(result.contains(Item("id" -> "ifne-b", "score" -> 0)))
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // List and set update operations
+  // ---------------------------------------------------------------------------
+
+  private val listAndSetUpdateTests: Spec[DynamoDBEnv, Throwable] =
+    suite("list and set update operations")(
+      test("appendList extends the list at the tail") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "list-a", "xs" -> List(1))))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "list-a")) {
+                          $("xs").appendList(List(2, 3))
+                        }
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "list-a")))
+          } yield {
+            val xs = result.flatMap(_.map.get("xs")).collect { case AttributeValue.List(v) =>
+              v.collect { case AttributeValue.Number(n) => n.intValue }.toList
+            }
+            assertTrue(xs.contains(List(1, 2, 3)))
+          }
+        }
+      },
+      test("prependList extends the list at the head") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "list-b", "xs" -> List(3))))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "list-b")) {
+                          $("xs").prependList(List(1, 2))
+                        }
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "list-b")))
+          } yield {
+            val xs = result.flatMap(_.map.get("xs")).collect { case AttributeValue.List(v) =>
+              v.collect { case AttributeValue.Number(n) => n.intValue }.toList
+            }
+            assertTrue(xs.contains(List(1, 2, 3)))
+          }
+        }
+      },
+      test("RemoveAction removes a list element by index") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "list-c", "xs" -> List(1, 2, 3))))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "list-c")) {
+                          UpdateExpression.Action.RemoveAction($("xs[1]"))
+                        }
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "list-c")))
+          } yield {
+            val xs = result.flatMap(_.map.get("xs")).collect { case AttributeValue.List(v) =>
+              v.collect { case AttributeValue.Number(n) => n.intValue }.toList
+            }
+            assertTrue(xs.contains(List(1, 3)))
+          }
+        }
+      },
+      test("addSet adds elements to a number set") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "set-a", "ns" -> Set(1, 2, 3))))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "set-a"))($("ns").addSet(Set(4)))
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "set-a")))
+          } yield {
+            val ns = result.flatMap(_.getOption[Set[Int]]("ns"))
+            assertTrue(ns.contains(Set(1, 2, 3, 4)))
+          }
+        }
+      },
+      test("deleteFromSet removes elements from a number set") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "set-b", "ns" -> Set(1, 2, 3))))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "set-b"))($("ns").deleteFromSet(Set(3)))
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "set-b")))
+          } yield {
+            val ns = result.flatMap(_.getOption[Set[Int]]("ns"))
+            assertTrue(ns.contains(Set(1, 2)))
+          }
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // Sort key range operators (< / >= / <= / between)
+  // ---------------------------------------------------------------------------
+
+  private val sortKeyRangeTests: Spec[DynamoDBEnv, Throwable] =
+    suite("querySome sort key range operators")(
+      test("sort key < returns items with sk strictly less than the bound") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-a", "year" -> "2021")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-a", "year" -> "2022")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-a", "year" -> "2023")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "skr-a" && $("year").sortKey < "2022")
+                    )
+          } yield assertTrue(page.items.length == 1)
+        }
+      },
+      test("sort key >= returns items with sk greater than or equal to the bound") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-b", "year" -> "2021")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-b", "year" -> "2022")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-b", "year" -> "2023")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "skr-b" && $("year").sortKey >= "2022")
+                    )
+          } yield assertTrue(page.items.length == 2)
+        }
+      },
+      test("sort key <= returns items with sk less than or equal to the bound") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-c", "year" -> "2021")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-c", "year" -> "2022")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-c", "year" -> "2023")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "skr-c" && $("year").sortKey <= "2022")
+                    )
+          } yield assertTrue(page.items.length == 2)
+        }
+      },
+      test("sort key between returns items with sk in the inclusive range") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-d", "year" -> "2021")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-d", "year" -> "2022")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-d", "year" -> "2023")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "skr-d", "year" -> "2024")))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "skr-d" && $("year").sortKey.between("2022", "2023"))
+                    )
+          } yield assertTrue(page.items.length == 2)
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // Condition expression variants (between / in / beginsWith / contains)
+  // ---------------------------------------------------------------------------
+
+  private val conditionExpressionTests: Spec[DynamoDBEnv, Throwable] =
+    suite("condition expression variants")(
+      test("between condition: deleteItem succeeds when attribute value is in range") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "cond-bt", "score" -> 50)))
+            _      <- interpreter.run(
+                        DynamoDBQuery
+                          .deleteItem(table, PrimaryKey("id" -> "cond-bt"))
+                          .where($("score").between(40, 60))
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "cond-bt")))
+          } yield assertTrue(result.isEmpty)
+        }
+      },
+      test("in condition: deleteItem succeeds when attribute value is in the set") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "cond-in", "status" -> "active")))
+            _      <- interpreter.run(
+                        DynamoDBQuery
+                          .deleteItem(table, PrimaryKey("id" -> "cond-in"))
+                          .where($("status").in("active", "pending"))
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "cond-in")))
+          } yield assertTrue(result.isEmpty)
+        }
+      },
+      test("beginsWith condition: deleteItem succeeds when attribute value starts with prefix") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "cond-bw", "name" -> "alice")))
+            _      <- interpreter.run(
+                        DynamoDBQuery
+                          .deleteItem(table, PrimaryKey("id" -> "cond-bw"))
+                          .where(ConditionExpression.BeginsWith($("name"), AttributeValue.String("al")))
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "cond-bw")))
+          } yield assertTrue(result.isEmpty)
+        }
+      },
+      test("contains condition: deleteItem succeeds when string attribute contains the substring") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "cond-ct", "name" -> "hello world")))
+            _      <- interpreter.run(
+                        DynamoDBQuery
+                          .deleteItem(table, PrimaryKey("id" -> "cond-ct"))
+                          .where($("name").contains("hello"))
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "cond-ct")))
+          } yield assertTrue(result.isEmpty)
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // Reserved keyword attribute names in filter/condition expressions
+  // ---------------------------------------------------------------------------
+
+  private val reservedKeywordTests: Spec[DynamoDBEnv, Throwable] =
+    suite("reserved keyword attribute names")(
+      test("scanSome.filter with AttributeNotExists on a DynamoDB reserved word succeeds") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "rk-1")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "rk-2")))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "rk-3", "ttl" -> 9999)))
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .scanSome(table, limit = 10)
+                        .filter(ConditionExpression.AttributeNotExists($("ttl")))
+                    )
+          } yield assertTrue(page.items.length == 2)
+        }
+      },
+      test("querySome.filter with AttributeNotExists on a DynamoDB reserved word succeeds") {
+        withIdAndYearKeyTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "rk-q", "year" -> "2022")))
+            _    <- interpreter.run(
+                      DynamoDBQuery.putItem(table, Item("id" -> "rk-q", "year" -> "2023", "ttl" -> 9999))
+                    )
+            page <- interpreter.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "rk-q")
+                        .filter(ConditionExpression.AttributeNotExists($("ttl")))
+                    )
+          } yield assertTrue(page.items.length == 1)
+        }
+      },
+      test("putItem.where with AttributeNotExists on a DynamoDB reserved word succeeds") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "rk-p", "score" -> 0)))
+            _      <- interpreter.run(
+                        DynamoDBQuery
+                          .putItem(table, Item("id" -> "rk-p", "score" -> 1))
+                          .where(ConditionExpression.AttributeNotExists($("ttl")))
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "rk-p")))
+          } yield assertTrue(result.contains(Item("id" -> "rk-p", "score" -> 1)))
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // Projection expression edge cases
+  // ---------------------------------------------------------------------------
+  // TODO: streaming operations (scanAll / queryAll / parallel scan) are not
+  // available in the new LL API; add tests here when they are implemented.
+
+  private val projectionTests: Spec[DynamoDBEnv, Throwable] =
+    suite("projection expression edge cases")(
+      test("nested map field projection returns only the nested value") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(
+                        DynamoDBQuery.putItem(
+                          table,
+                          Item("id" -> "pe-nm", "stats" -> Map("wins" -> 10, "losses" -> 5))
+                        )
+                      )
+            result <- interpreter.run(
+                        DynamoDBQuery.getItem(table, PrimaryKey("id" -> "pe-nm"), $("stats.wins"))
+                      )
+          } yield assertTrue(result.contains(Item("stats" -> Map("wins" -> 10))))
+        }
+      },
+      test("backtick-quoted field name containing a dot is projected correctly") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "pe-bt", "foo.bar" -> "value")))
+            result <- interpreter.run(
+                        DynamoDBQuery.getItem(table, PrimaryKey("id" -> "pe-bt"), $("`foo.bar`"))
+                      )
+          } yield assertTrue(result.contains(Item("foo.bar" -> "value")))
+        }
+      },
+      test("hyphen in field name is projected correctly") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "pe-hy", "foo-bar" -> "value")))
+            result <- interpreter.run(
+                        DynamoDBQuery.getItem(table, PrimaryKey("id" -> "pe-hy"), $("foo-bar"))
+                      )
+          } yield assertTrue(result.contains(Item("foo-bar" -> "value")))
+        }
+      },
+      test("backtick-quoted field name works in condition expression") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bt-ce", "foo.bar" -> "original")))
+            _      <- interpreter.run(
+                        DynamoDBQuery
+                          .putItem(table, Item("id" -> "bt-ce", "foo.bar" -> "updated"))
+                          .where($("`foo.bar`") === "original")
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "bt-ce")))
+          } yield assertTrue(result.contains(Item("id" -> "bt-ce", "foo.bar" -> "updated")))
+        }
+      },
+      test("backtick-quoted field name works in update expression") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "bt-ue", "foo.bar" -> "before")))
+            _      <- interpreter.run(
+                        DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "bt-ue")) {
+                          $("`foo.bar`").set("after")
+                        }
+                      )
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "bt-ue")))
+          } yield assertTrue(result.contains(Item("id" -> "bt-ue", "foo.bar" -> "after")))
+        }
+      }
+    )
+
+  def spec = suite("DynamoDB CRUD")(
+    suite("ZIO interpreter")(
+      singleKeyTests,
+      compositeKeyTests,
+      batchingTests,
+      batchGetItemTests,
+      updateItemTests,
+      conditionAndFilterTests,
+      querySomeTests,
+      capacityTests,
+      consistencyTests,
+      returnsTests,
+      startKeyTests,
+      segmentTests,
+      selectTests,
+      gsiTests,
+      lsiTests,
+      allAttributeTypesTests,
+      updateReturnValuesExtendedTests,
+      updateArithmeticTests,
+      listAndSetUpdateTests,
+      sortKeyRangeTests,
+      conditionExpressionTests,
+      reservedKeywordTests,
+      projectionTests
+    )
+      .provideSome[DynamoDbAsyncClient](zioEnvLayer),
+    suite("CE interpreter")(
+      singleKeyTests,
+      compositeKeyTests,
+      batchingTests,
+      batchGetItemTests,
+      updateItemTests,
+      conditionAndFilterTests,
+      querySomeTests,
+      capacityTests,
+      consistencyTests,
+      returnsTests,
+      startKeyTests,
+      segmentTests,
+      selectTests,
+      gsiTests,
+      lsiTests,
+      allAttributeTypesTests,
+      updateReturnValuesExtendedTests,
+      updateArithmeticTests,
+      listAndSetUpdateTests,
+      sortKeyRangeTests,
+      conditionExpressionTests,
+      reservedKeywordTests,
+      projectionTests
+    )
+      .provideSome[DynamoDbAsyncClient](ceEnvLayer),
+    suite("Future interpreter")(
+      singleKeyTests,
+      compositeKeyTests,
+      batchingTests,
+      batchGetItemTests,
+      updateItemTests,
+      conditionAndFilterTests,
+      querySomeTests,
+      capacityTests,
+      consistencyTests,
+      returnsTests,
+      startKeyTests,
+      segmentTests,
+      selectTests,
+      gsiTests,
+      lsiTests,
+      allAttributeTypesTests,
+      updateReturnValuesExtendedTests,
+      updateArithmeticTests,
+      listAndSetUpdateTests,
+      sortKeyRangeTests,
+      conditionExpressionTests,
+      reservedKeywordTests,
+      projectionTests
+    )
+      .provideSome[DynamoDbAsyncClient](futureEnvLayer)
+  ) @@ TestAspect.sequential
+}

--- a/it/src/test/scala/zio/dynamodb/InterceptorSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/InterceptorSpec.scala
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2021-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.dynamodb
+
+import cats.effect.{ IO => CIO, Ref => CRef }
+import cats.effect.unsafe.implicits.{ global => ceRuntime }
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import zio._
+import zio.blocks.chunk.Chunk
+import zio.dynamodb.ProjectionExpression.$
+import zio.test._
+import zio.test.TestAspect
+
+import scala.concurrent.ExecutionContext
+
+object InterceptorSpec extends DynamoDBLocalSpec {
+
+  // Base env — ZIO interpreter used only for test data setup.
+  private val envLayer: URLayer[DynamoDbAsyncClient, DynamoDBEnv] =
+    ZLayer(ZIO.serviceWith[DynamoDbAsyncClient](client => DynamoDBEnv(client, ZioInterpreter.fromAsyncClient(client))))
+
+  private implicit val ec: ExecutionContext = ExecutionContext.global
+
+  // -- Effect-system bridges --------------------------------------------------
+
+  private def ceBridge(ceInterp: CEInterpreter): Interpreter[Task] =
+    new Interpreter[Task] {
+      def run[A](q: DynamoDBQuery[_, A]): Task[A] =
+        ZIO.fromFuture(_ => ceInterp.run(q).unsafeToFuture()(ceRuntime))
+    }
+
+  private def futureBridge(interp: FutureInterpreter): Interpreter[Task] =
+    new Interpreter[Task] {
+      def run[A](q: DynamoDBQuery[_, A]): Task[A] =
+        ZIO.fromFuture(_ => interp.run(q)).mapError {
+          case e: java.util.concurrent.CompletionException if e.getCause != null => e.getCause
+          case e                                                                 => e
+        }
+    }
+
+  // -- Table helpers (same as InterceptorSpec original) ----------------------
+
+  private def withInterceptingTable(
+    f: (String, Interpreter[Task], DynamoDbAsyncClient) => ZIO[Any, Throwable, TestResult]
+  ): ZIO[DynamoDBEnv & DynamoDbAsyncClient, Throwable, TestResult] =
+    ZIO.scoped {
+      for {
+        env    <- ZIO.service[DynamoDBEnv]
+        client <- ZIO.service[DynamoDbAsyncClient]
+        table  <- managedTable(singleIdKeyTable)
+        result <- f(table, env.interpreter, client)
+      } yield result
+    }
+
+  private def withInterceptingYearTable(
+    f: (String, Interpreter[Task], DynamoDbAsyncClient) => ZIO[Any, Throwable, TestResult]
+  ): ZIO[DynamoDBEnv & DynamoDbAsyncClient, Throwable, TestResult] =
+    ZIO.scoped {
+      for {
+        env    <- ZIO.service[DynamoDBEnv]
+        client <- ZIO.service[DynamoDbAsyncClient]
+        table  <- managedTable(idAndYearKeyTable)
+        result <- f(table, env.interpreter, client)
+      } yield result
+    }
+
+  // -- Accumulator factories --------------------------------------------------
+  //
+  // Each factory produces, for a given client, an intercepting Interpreter[Task]
+  // and a Task that reads the metadata accumulated so far.
+
+  private type AccFactory =
+    DynamoDbAsyncClient => Task[(Interpreter[Task], Task[Chunk[DynamoDBResponseMetadata]])]
+
+  private val zioAccFactory: AccFactory = client =>
+    ZioResponseInterceptor.accumulating.map { acc =>
+      val itInterp: Interpreter[Task] = ZioInterpreter.fromAsyncClient(client, acc.interceptor)
+      (itInterp, acc.results)
+    }
+
+  // CE uses cats.effect.Ref (shared across unsafeToFuture() boundaries) rather
+  // than IOLocal so metadata written inside ceBridge calls is visible when we
+  // read results from a separate unsafeToFuture() call.
+  private val ceAccFactory: AccFactory = client =>
+    ZIO.fromFuture { _ =>
+      CRef
+        .of[CIO, List[DynamoDBResponseMetadata]](List.empty)
+        .map { ref =>
+          val interceptor: ResponseInterceptor[CIO]          = new ResponseInterceptor[CIO] {
+            def onResponse(meta: DynamoDBResponseMetadata): CIO[Unit] = ref.update(meta :: _)
+          }
+          val readMeta: CIO[Chunk[DynamoDBResponseMetadata]] =
+            ref.get.map(xs => Chunk.fromIterable(xs.reverse))
+          (CEInterpreter.fromAsyncClient(client, interceptor), readMeta)
+        }
+        .unsafeToFuture()(ceRuntime)
+    }.map { case (ceInterp, readMetaCIO) =>
+      val itInterp: Interpreter[Task]                     = ceBridge(ceInterp)
+      val readMeta: Task[Chunk[DynamoDBResponseMetadata]] =
+        ZIO.fromFuture(_ => readMetaCIO.unsafeToFuture()(ceRuntime))
+      (itInterp, readMeta)
+    }
+
+  private val futureAccFactory: AccFactory = client =>
+    ZIO.fromFuture(_ => FutureResponseInterceptor.accumulating).map { acc =>
+      val itInterp: Interpreter[Task]                     = futureBridge(FutureInterpreter.fromAsyncClient(client, acc.interceptor))
+      val readMeta: Task[Chunk[DynamoDBResponseMetadata]] = ZIO.succeed(acc.results())
+      (itInterp, readMeta)
+    }
+
+  // -- Generic interceptor test suite ----------------------------------------
+
+  private def interceptorSuite(
+    name: String,
+    factory: AccFactory
+  ): Spec[DynamoDBEnv & DynamoDbAsyncClient, Throwable] =
+    suite(name)(
+      test("getItem fires interceptor with correct tableName and PK") {
+        withInterceptingTable { (table, plainInterp, asyncClient) =>
+          val pk = PrimaryKey("id" -> "alice")
+          for {
+            pair <- factory(asyncClient)
+            (itInterp, readMeta) = pair
+            _    <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "alice")))
+            _    <- itInterp.run(DynamoDBQuery.getItem(table, pk))
+            meta <- readMeta
+          } yield {
+            val m = meta(0).asInstanceOf[DynamoDBResponseMetadata.GetItem]
+            assertTrue(
+              meta.length == 1 &&
+                m.tableName == table &&
+                m.correlation.primaryKey.contains(pk)
+            )
+          }
+        }
+      },
+      test("putItem fires interceptor with PutItem metadata; correlation.primaryKey is None") {
+        withInterceptingTable { (table, _, asyncClient) =>
+          for {
+            pair <- factory(asyncClient)
+            (itInterp, readMeta) = pair
+            _    <- itInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "bob")))
+            meta <- readMeta
+          } yield {
+            val m = meta(0).asInstanceOf[DynamoDBResponseMetadata.PutItem]
+            assertTrue(
+              meta.length == 1 &&
+                m.tableName == table &&
+                m.correlation.primaryKey.isEmpty
+            )
+          }
+        }
+      },
+      test("updateItem fires interceptor with UpdateItem metadata and PK in correlation") {
+        withInterceptingTable { (table, plainInterp, asyncClient) =>
+          val pk = PrimaryKey("id" -> "charlie")
+          for {
+            pair <- factory(asyncClient)
+            (itInterp, readMeta) = pair
+            _    <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "charlie", "score" -> 0)))
+            _    <- itInterp.run(DynamoDBQuery.updateItem(table, pk)($("score").set(1)))
+            meta <- readMeta
+          } yield {
+            val m = meta(0).asInstanceOf[DynamoDBResponseMetadata.UpdateItem]
+            assertTrue(
+              meta.length == 1 &&
+                m.tableName == table &&
+                m.correlation.primaryKey.contains(pk)
+            )
+          }
+        }
+      },
+      test("deleteItem fires interceptor with DeleteItem metadata and PK in correlation") {
+        withInterceptingTable { (table, plainInterp, asyncClient) =>
+          val pk = PrimaryKey("id" -> "dave")
+          for {
+            pair <- factory(asyncClient)
+            (itInterp, readMeta) = pair
+            _    <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "dave")))
+            _    <- itInterp.run(DynamoDBQuery.deleteItem(table, pk))
+            meta <- readMeta
+          } yield {
+            val m = meta(0).asInstanceOf[DynamoDBResponseMetadata.DeleteItem]
+            assertTrue(
+              meta.length == 1 &&
+                m.tableName == table &&
+                m.correlation.primaryKey.contains(pk)
+            )
+          }
+        }
+      },
+      test("scanSome fires interceptor with Scan metadata") {
+        withInterceptingTable { (table, plainInterp, asyncClient) =>
+          for {
+            pair <- factory(asyncClient)
+            (itInterp, readMeta) = pair
+            _    <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "s1")))
+            _    <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "s2")))
+            _    <- itInterp.run(DynamoDBQuery.scanSome(table, limit = 10))
+            meta <- readMeta
+          } yield {
+            val m = meta(0).asInstanceOf[DynamoDBResponseMetadata.Scan]
+            assertTrue(meta.length == 1 && m.tableName == table)
+          }
+        }
+      },
+      test("querySome fires interceptor with Query metadata") {
+        withInterceptingYearTable { (table, plainInterp, asyncClient) =>
+          for {
+            pair <- factory(asyncClient)
+            (itInterp, readMeta) = pair
+            _    <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "alice", "year" -> "2024")))
+            _    <- itInterp.run(
+                      DynamoDBQuery
+                        .querySome(table, limit = 10)
+                        .whereKey($("id").partitionKey === "alice")
+                    )
+            meta <- readMeta
+          } yield {
+            val m = meta(0).asInstanceOf[DynamoDBResponseMetadata.Query]
+            assertTrue(meta.length == 1 && m.tableName == table)
+          }
+        }
+      },
+      test("batchGetItem fires interceptor with BatchGetItem metadata") {
+        withInterceptingTable { (table, plainInterp, asyncClient) =>
+          for {
+            pair <- factory(asyncClient)
+            (itInterp, readMeta) = pair
+            _    <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "a", "v" -> 1)))
+            _    <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "b", "v" -> 2)))
+            batch =
+              DynamoDBQuery.batchGetItem(List("a", "b"))(id => DynamoDBQuery.getItem(table, PrimaryKey("id" -> id)))
+            _    <- itInterp.run(batch)
+            meta <- readMeta
+          } yield assertTrue(
+            meta.length == 1 &&
+              meta(0).isInstanceOf[DynamoDBResponseMetadata.BatchGetItem]
+          )
+        }
+      },
+      test("batchWriteItem fires interceptor with BatchWriteItem metadata") {
+        withInterceptingTable { (table, _, asyncClient) =>
+          val items = List(Item("id" -> "x", "v" -> 1), Item("id" -> "y", "v" -> 2))
+          for {
+            pair <- factory(asyncClient)
+            (itInterp, readMeta) = pair
+            _    <- itInterp.run(DynamoDBQuery.batchWriteItem(items)(item => DynamoDBQuery.putItem(table, item)))
+            meta <- readMeta
+          } yield assertTrue(
+            meta.length == 1 &&
+              meta(0).isInstanceOf[DynamoDBResponseMetadata.BatchWriteItem]
+          )
+        }
+      },
+      test("accumulation: two operations produce two metadata entries in order") {
+        withInterceptingTable { (table, _, asyncClient) =>
+          val pk = PrimaryKey("id" -> "acc-test")
+          for {
+            pair <- factory(asyncClient)
+            (itInterp, readMeta) = pair
+            _    <- itInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "acc-test")))
+            _    <- itInterp.run(DynamoDBQuery.getItem(table, pk))
+            meta <- readMeta
+          } yield assertTrue(
+            meta.length == 2 &&
+              meta(0).isInstanceOf[DynamoDBResponseMetadata.PutItem] &&
+              meta(1).isInstanceOf[DynamoDBResponseMetadata.GetItem]
+          )
+        }
+      }
+    )
+
+  def spec = suite("Interceptor IT")(
+    interceptorSuite("ZIO interpreter", zioAccFactory),
+    interceptorSuite("CE interpreter", ceAccFactory),
+    interceptorSuite("Future interpreter", futureAccFactory),
+    test("no-interceptor baseline: plain interpreter produces no metadata") {
+      withSingleIdKeyTable { (table, plainInterp) =>
+        for {
+          _ <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "baseline")))
+          r <- plainInterp.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "baseline")))
+        } yield assertTrue(r.isDefined)
+      }
+    }
+  ).provideSome[DynamoDbAsyncClient](envLayer) @@ TestAspect.sequential
+}

--- a/it/src/test/scala/zio/dynamodb/InterceptorSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/InterceptorSpec.scala
@@ -138,14 +138,11 @@ object InterceptorSpec extends DynamoDBLocalSpec {
             _    <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "alice")))
             _    <- itInterp.run(DynamoDBQuery.getItem(table, pk))
             meta <- readMeta
-          } yield {
-            val m = meta(0).asInstanceOf[DynamoDBResponseMetadata.GetItem]
-            assertTrue(
-              meta.length == 1 &&
-                m.tableName == table &&
-                m.correlation.primaryKey.contains(pk)
-            )
-          }
+          } yield assertTrue(meta.toList match {
+            case (m: DynamoDBResponseMetadata.GetItem) :: Nil =>
+              m.tableName == table && m.correlation.primaryKey.contains(pk)
+            case _                                            => false
+          })
         }
       },
       test("putItem fires interceptor with PutItem metadata; correlation.primaryKey is None") {
@@ -155,14 +152,11 @@ object InterceptorSpec extends DynamoDBLocalSpec {
             (itInterp, readMeta) = pair
             _    <- itInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "bob")))
             meta <- readMeta
-          } yield {
-            val m = meta(0).asInstanceOf[DynamoDBResponseMetadata.PutItem]
-            assertTrue(
-              meta.length == 1 &&
-                m.tableName == table &&
-                m.correlation.primaryKey.isEmpty
-            )
-          }
+          } yield assertTrue(meta.toList match {
+            case (m: DynamoDBResponseMetadata.PutItem) :: Nil =>
+              m.tableName == table && m.correlation.primaryKey.isEmpty
+            case _                                            => false
+          })
         }
       },
       test("updateItem fires interceptor with UpdateItem metadata and PK in correlation") {
@@ -174,14 +168,11 @@ object InterceptorSpec extends DynamoDBLocalSpec {
             _    <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "charlie", "score" -> 0)))
             _    <- itInterp.run(DynamoDBQuery.updateItem(table, pk)($("score").set(1)))
             meta <- readMeta
-          } yield {
-            val m = meta(0).asInstanceOf[DynamoDBResponseMetadata.UpdateItem]
-            assertTrue(
-              meta.length == 1 &&
-                m.tableName == table &&
-                m.correlation.primaryKey.contains(pk)
-            )
-          }
+          } yield assertTrue(meta.toList match {
+            case (m: DynamoDBResponseMetadata.UpdateItem) :: Nil =>
+              m.tableName == table && m.correlation.primaryKey.contains(pk)
+            case _                                               => false
+          })
         }
       },
       test("deleteItem fires interceptor with DeleteItem metadata and PK in correlation") {
@@ -193,14 +184,11 @@ object InterceptorSpec extends DynamoDBLocalSpec {
             _    <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "dave")))
             _    <- itInterp.run(DynamoDBQuery.deleteItem(table, pk))
             meta <- readMeta
-          } yield {
-            val m = meta(0).asInstanceOf[DynamoDBResponseMetadata.DeleteItem]
-            assertTrue(
-              meta.length == 1 &&
-                m.tableName == table &&
-                m.correlation.primaryKey.contains(pk)
-            )
-          }
+          } yield assertTrue(meta.toList match {
+            case (m: DynamoDBResponseMetadata.DeleteItem) :: Nil =>
+              m.tableName == table && m.correlation.primaryKey.contains(pk)
+            case _                                               => false
+          })
         }
       },
       test("scanSome fires interceptor with Scan metadata") {
@@ -212,10 +200,10 @@ object InterceptorSpec extends DynamoDBLocalSpec {
             _    <- plainInterp.run(DynamoDBQuery.putItem(table, Item("id" -> "s2")))
             _    <- itInterp.run(DynamoDBQuery.scanSome(table, limit = 10))
             meta <- readMeta
-          } yield {
-            val m = meta(0).asInstanceOf[DynamoDBResponseMetadata.Scan]
-            assertTrue(meta.length == 1 && m.tableName == table)
-          }
+          } yield assertTrue(meta.toList match {
+            case (m: DynamoDBResponseMetadata.Scan) :: Nil => m.tableName == table
+            case _                                         => false
+          })
         }
       },
       test("querySome fires interceptor with Query metadata") {
@@ -230,10 +218,10 @@ object InterceptorSpec extends DynamoDBLocalSpec {
                         .whereKey($("id").partitionKey === "alice")
                     )
             meta <- readMeta
-          } yield {
-            val m = meta(0).asInstanceOf[DynamoDBResponseMetadata.Query]
-            assertTrue(meta.length == 1 && m.tableName == table)
-          }
+          } yield assertTrue(meta.toList match {
+            case (m: DynamoDBResponseMetadata.Query) :: Nil => m.tableName == table
+            case _                                          => false
+          })
         }
       },
       test("batchGetItem fires interceptor with BatchGetItem metadata") {

--- a/it/src/test/scala/zio/dynamodb/OopModelLowLevelApiSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/OopModelLowLevelApiSpec.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2021-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.dynamodb
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import zio._
+import zio.blocks.schema.{ Modifier, Schema }
+import zio.dynamodb.blocks.schema.{ DynamoDBCodec, DynamoDBCodecDeriver }
+import zio.dynamodb.ProjectionExpression.$
+import zio.test._
+import zio.test.TestAspect
+
+// Integration-test companion to
+// schema-ddbexpr/src/test/scala/zio/dynamodb/OopModelWithAbstractFieldsSpec.scala.
+// See docs/design/SumTypesWithAbstractFields.md for the full design discussion — in short:
+// a root-level OO model with abstract/shared fields (`.id` on every case, `.amount` shared
+// by the Billed cases) is only usable as a real top-level DynamoDB item at all — for *any*
+// API, HL or LL — under `@Modifier.discriminator` (Field-style). Under this project's
+// default Key-style, DynamoDBCodecDeriver wraps the *entire* encoded record under the leaf
+// case's own name, so even a root-shared field like `id` ends up nested one level down —
+// confirmed directly against a real table: `putItem` fails with "One of the required keys
+// was not given a value", because `id` genuinely isn't a top-level attribute in the item.
+// Field-style keeps every field flat and case-name-independent, so `id` is a valid
+// partition key and `amount` matches uniformly across cases with a single filter — no
+// per-case wrapper path, no manual Or, proven here against a real DynamoDB Local instance.
+// Queried purely through the LL API + DynamoDBCodec.toItem/fromItem — this project's HL
+// API optic sugar is deliberately never offered for abstract-declared fields (see the
+// doc's TL;DR), so there's no ZB-side dependency here at all, local or published — and
+// no Scala-3-only syntax either, hence plain (cross-compiled) source, not scala-3/.
+@Modifier.discriminator("_type")
+sealed trait OopInvoice { def id: Int }
+object OopInvoice       {
+  implicit val schema: Schema[OopInvoice] = Schema.derived
+}
+
+sealed trait OopBilled extends OopInvoice { def amount: Double }
+
+case class OopBilledMonthly(id: Int, amount: Double, month: Int) extends OopBilled
+object OopBilledMonthly {
+  implicit val schema: Schema[OopBilledMonthly] = Schema.derived
+}
+
+case class OopBilledYearly(id: Int, amount: Double, year: Int) extends OopBilled
+object OopBilledYearly {
+  implicit val schema: Schema[OopBilledYearly] = Schema.derived
+}
+
+case class OopPrebilled(id: Int, count: Int) extends OopInvoice
+object OopPrebilled {
+  implicit val schema: Schema[OopPrebilled] = Schema.derived
+}
+
+object OopModelLowLevelApiSpec extends DynamoDBLocalSpec {
+
+  private val codec: DynamoDBCodec[OopInvoice] = Schema[OopInvoice].deriving(DynamoDBCodecDeriver).derive
+
+  // id is the model's Int partition key — a Number attribute, not the String key that
+  // DynamoDBLocalSpec's own withSingleIdKeyTable assumes, so this test defines its own
+  // table shape rather than reusing that helper.
+  private def oopInvoiceTable(tableName: String): DynamoDBQuery[Any, Unit] =
+    DynamoDBQuery.createTable(
+      tableName,
+      KeySchema("id"),
+      NonEmptySet(AttributeDefinition.attrDefnNumber("id")),
+      BillingMode.PayPerRequest
+    )
+
+  private def withOopInvoiceTable(
+    f: (String, Interpreter[Task]) => ZIO[Any, Throwable, TestResult]
+  ): ZIO[DynamoDBEnv, Throwable, TestResult] =
+    ZIO.scoped {
+      for {
+        table  <- managedTable(oopInvoiceTable)
+        env    <- ZIO.service[DynamoDBEnv]
+        result <- f(table, env.interpreter)
+      } yield result
+    }
+
+  private val envLayer: URLayer[DynamoDbAsyncClient, DynamoDBEnv] =
+    ZLayer(ZIO.serviceWith[DynamoDbAsyncClient](client => DynamoDBEnv(client, ZioInterpreter.fromAsyncClient(client))))
+
+  def spec =
+    suite("OO model (Field-style discriminator) via the LL API against real DynamoDB Local")(
+      test("id is a genuine top-level attribute — A -> Item -> A round-trips through putItem/getItem") {
+        withOopInvoiceTable { (table, interpreter) =>
+          val original: OopInvoice = OopBilledMonthly(1, 42.0, 3)
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, codec.toItem(original)))
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> 1)))
+          } yield assertTrue(result.map(codec.fromItem) == Some(Right(original)))
+        }
+      },
+      test("every case's id round-trips as a valid partition key, including the non-Billed case") {
+        withOopInvoiceTable { (table, interpreter) =>
+          val prebilled: OopInvoice = OopPrebilled(3, 5)
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, codec.toItem(prebilled)))
+            result <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> 3)))
+          } yield assertTrue(result.map(codec.fromItem) == Some(Right(prebilled)))
+        }
+      },
+      test("one flat filter on amount matches across every Billed case — no per-case wrapper, no manual Or") {
+        withOopInvoiceTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, codec.toItem(OopBilledMonthly(1, 42.0, 3))))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, codec.toItem(OopBilledYearly(2, 42.0, 2024))))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, codec.toItem(OopPrebilled(3, 5))))
+            page <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 10).filter($("amount") === 42.0))
+            decoded = page.items.map(codec.fromItem).toSet
+          } yield assertTrue(
+            page.items.length == 2,
+            decoded == Set[Either[DynamoDBError.ItemError.DecodingError, OopInvoice]](
+              Right(OopBilledMonthly(1, 42.0, 3)),
+              Right(OopBilledYearly(2, 42.0, 2024))
+            )
+          )
+        }
+      },
+      test("the same flat filter correctly excludes the case that has no amount field at all") {
+        withOopInvoiceTable { (table, interpreter) =>
+          for {
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, codec.toItem(OopBilledMonthly(1, 42.0, 3))))
+            _    <- interpreter.run(DynamoDBQuery.putItem(table, codec.toItem(OopPrebilled(3, 5))))
+            page <- interpreter.run(DynamoDBQuery.scanSome(table, limit = 10).filter($("amount") === 42.0))
+            decoded = page.items.map(codec.fromItem)
+          } yield assertTrue(
+            page.items.length == 1,
+            decoded == zio.blocks.chunk.Chunk(Right(OopBilledMonthly(1, 42.0, 3)))
+          )
+        }
+      }
+    ).provideSome[DynamoDbAsyncClient](envLayer) @@ TestAspect.sequential
+}

--- a/it/src/test/scala/zio/dynamodb/TransactionSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/TransactionSpec.scala
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2021-2026 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.dynamodb
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import zio._
+import zio.dynamodb.DynamoDBError.TransactionError
+import zio.dynamodb.ProjectionExpression.$
+import zio.test._
+import zio.test.Assertion.{ anything, equalTo, hasField, isLeft, isNone, isSome, isSubtype }
+
+object TransactionSpec extends DynamoDBLocalSpec {
+
+  private val zioEnvLayer: URLayer[DynamoDbAsyncClient, DynamoDBEnv] =
+    ZLayer(ZIO.serviceWith[DynamoDbAsyncClient](client => DynamoDBEnv(client, ZioInterpreter.fromAsyncClient(client))))
+
+  // ---------------------------------------------------------------------------
+  // transactGetItems happy paths
+  // ---------------------------------------------------------------------------
+
+  private val transactGetTests: Spec[DynamoDBEnv, Throwable] =
+    suite("transactGetItems")(
+      test("reads two existing items — results match what was put, in order") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _       <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "a", "v" -> 1)))
+            _       <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "b", "v" -> 2)))
+            results <- interpreter.run(
+                         DynamoDBQuery.transactGetItems(
+                           DynamoDBQuery.GetItem(table, PrimaryKey("id" -> "a")),
+                           DynamoDBQuery.GetItem(table, PrimaryKey("id" -> "b"))
+                         )
+                       )
+          } yield assertTrue(
+            results(0).contains(Item("id" -> "a", "v" -> 1)) &&
+              results(1).contains(Item("id" -> "b", "v" -> 2))
+          )
+        }
+      },
+      test("item not found → None at that position; existing item → Some with correct content") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _       <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "present", "v" -> 7)))
+            results <- interpreter.run(
+                         DynamoDBQuery.transactGetItems(
+                           DynamoDBQuery.GetItem(table, PrimaryKey("id" -> "present")),
+                           DynamoDBQuery.GetItem(table, PrimaryKey("id" -> "absent"))
+                         )
+                       )
+          } yield assertTrue(
+            results(0).contains(Item("id" -> "present", "v" -> 7)) &&
+              results(1).isEmpty
+          )
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // transactWriteItems happy paths
+  // ---------------------------------------------------------------------------
+
+  private val transactWriteTests: Spec[DynamoDBEnv, Throwable] =
+    suite("transactWriteItems")(
+      test("puts two items atomically — both readable with correct content after") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _  <- interpreter.run(
+                    DynamoDBQuery.transactWriteItems(
+                      DynamoDBQuery.putItem(table, Item("id" -> "tx-a", "v" -> 1)),
+                      DynamoDBQuery.putItem(table, Item("id" -> "tx-b", "v" -> 2))
+                    )
+                  )
+            ra <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "tx-a")))
+            rb <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "tx-b")))
+          } yield assertTrue(
+            ra.contains(Item("id" -> "tx-a", "v" -> 1)) &&
+              rb.contains(Item("id" -> "tx-b", "v" -> 2))
+          )
+        }
+      },
+      test("update + delete atomically — updated item exists, deleted item gone") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _       <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "keep", "v" -> 0)))
+            _       <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "drop")))
+            _       <- interpreter.run(
+                         DynamoDBQuery.transactWriteItems(
+                           DynamoDBQuery.updateItem(table, PrimaryKey("id" -> "keep"))($("v").set(42)),
+                           DynamoDBQuery.deleteItem(table, PrimaryKey("id" -> "drop"))
+                         )
+                       )
+            kept    <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "keep")))
+            dropped <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "drop")))
+          } yield assertTrue(
+            kept.contains(Item("id" -> "keep", "v" -> 42)) &&
+              dropped.isEmpty
+          )
+        }
+      },
+      test("condition check passes — write proceeds") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _ <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "guarded", "status" -> "open")))
+            _ <- interpreter.run(
+                   DynamoDBQuery.transactWriteItems(
+                     DynamoDBQuery.conditionCheck(table, PrimaryKey("id" -> "guarded"))($("status") === "open"),
+                     DynamoDBQuery.putItem(table, Item("id" -> "new-item"))
+                   )
+                 )
+            r <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "new-item")))
+          } yield assertTrue(r.contains(Item("id" -> "new-item")))
+        }
+      },
+      test("idempotency: same clientRequestToken produces same result on replay") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          val token = java.util.UUID.randomUUID().toString
+          val tx    = DynamoDBQuery
+            .transactWriteItems(
+              DynamoDBQuery.putItem(table, Item("id" -> "idem", "v" -> 1))
+            )
+            .withClientRequestToken(token)
+          for {
+            _ <- interpreter.run(tx)
+            _ <- interpreter.run(tx) // replay with same token
+            r <- interpreter.run(DynamoDBQuery.getItem(table, PrimaryKey("id" -> "idem")))
+          } yield assertTrue(r.contains(Item("id" -> "idem", "v" -> 1)))
+        }
+      }
+    )
+
+  // ---------------------------------------------------------------------------
+  // transactWriteItems error paths
+  // ---------------------------------------------------------------------------
+
+  private val transactWriteErrorTests: Spec[DynamoDBEnv, Throwable] =
+    suite("transactWriteItems error paths")(
+      test("failed condition check → error message contains TransactionCancelled and ConditionalCheckFailed") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "locked", "status" -> "closed")))
+            result <- interpreter
+                        .run(
+                          DynamoDBQuery.transactWriteItems(
+                            // condition requires status=open but it's closed → will fail
+                            DynamoDBQuery.conditionCheck(table, PrimaryKey("id" -> "locked"))($("status") === "open"),
+                            DynamoDBQuery.putItem(table, Item("id" -> "should-not-write"))
+                          )
+                        )
+                        .either
+          } yield assert(result)(
+            // DynamoDB returns one reason per action: conditionCheck failed, putItem was not attempted ("None")
+            isLeft(
+              isSubtype[TransactionError.TransactionCancelled](
+                hasField(
+                  "reasons.length",
+                  (tc: TransactionError.TransactionCancelled) => tc.reasons.length,
+                  equalTo(2)
+                ) &&
+                  hasField(
+                    "reasons(0).code",
+                    (tc: TransactionError.TransactionCancelled) => tc.reasons(0).code,
+                    equalTo("ConditionalCheckFailed")
+                  ) &&
+                  hasField(
+                    "reasons(0).item",
+                    (tc: TransactionError.TransactionCancelled) => tc.reasons(0).item,
+                    isNone
+                  ) &&
+                  hasField(
+                    "reasons(1).code",
+                    (tc: TransactionError.TransactionCancelled) => tc.reasons(1).code,
+                    equalTo("None")
+                  )
+              )
+            )
+          )
+        }
+      },
+      test("failed condition with AllOld — cancellation reason message reflects attempted write was rejected") {
+        withSingleIdKeyTable { (table, interpreter) =>
+          for {
+            _      <- interpreter.run(DynamoDBQuery.putItem(table, Item("id" -> "item", "v" -> 0)))
+            result <- interpreter
+                        .run(
+                          DynamoDBQuery.transactWriteItems(
+                            DynamoDBQuery
+                              .updateItem(table, PrimaryKey("id" -> "item"))($("v").set(1))
+                              .where($("v") === 999) // impossible condition
+                              .returnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure.AllOld)
+                          )
+                        )
+                        .either
+          } yield assert(result)(
+            isLeft(
+              isSubtype[TransactionError.TransactionCancelled](
+                hasField(
+                  "reasons.length",
+                  (tc: TransactionError.TransactionCancelled) => tc.reasons.length,
+                  equalTo(1)
+                ) &&
+                  hasField(
+                    "reasons(0).code",
+                    (tc: TransactionError.TransactionCancelled) => tc.reasons(0).code,
+                    equalTo("ConditionalCheckFailed")
+                  ) &&
+                  hasField(
+                    "reasons(0).item",
+                    (tc: TransactionError.TransactionCancelled) => tc.reasons(0).item,
+                    isSome(anything)
+                  )
+              )
+            )
+          )
+        }
+      }
+    )
+
+  def spec = suite("TransactionSpec")(
+    suite("ZIO interpreter")(transactGetTests, transactWriteTests, transactWriteErrorTests)
+      .provideSome[DynamoDbAsyncClient](zioEnvLayer)
+  )
+}


### PR DESCRIPTION
Adds the integration test suite (BatchSpec, DdbExprApiSpec, DynamoDBLocalSpec, DynamoDBLowLevelApiSpec, InterceptorSpec, OopModelLowLevelApiSpec, TransactionSpec), depending on all four interpreters plus schema-dynamodb and schema-ddbexpr