### PR TITLE
Remove dangling DdbSchemaExprApi references from comments and scaladoc

### DIFF
--- a/it/src/test/scala/zio/dynamodb/DdbExprApiSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/DdbExprApiSpec.scala
@@ -32,16 +32,10 @@ import zio.test.TestAspect
 /**
  * Integration tests for [[DdbExprApi]].
  *
- *  Focuses on the correctness guarantee that distinguishes [[DdbExprApi]] from
- *  [[zio.dynamodb.blocks.DdbSchemaExprApi]]: sealed-trait literal values in
+ *  Focuses on the correctness guarantee that sealed-trait literal values in
  *  filter/condition expressions are encoded via [[zio.dynamodb.blocks.schema.DynamoDBCodec]]
- *  directly, not through a [[zio.blocks.schema.DynamicValue]] round-trip that loses
+ *  directly, not through a [[zio.blocks.schema.DynamicValue]] round-trip that would lose
  *  the `enumValuesAsStrings` encoding rule.
- *
- *  The cross-API proof test (suite 3) demonstrates this concretely: the same item
- *  with `priority = "High"` (as stored) is found by a [[DdbExprApi]] filter but
- *  missed by a [[zio.dynamodb.blocks.DdbSchemaExprApi]] filter, which generates
- *  `priority = {"High": {}}` for the same Scala expression.
  */
 object DdbExprApiSpec extends DynamoDBLocalSpec {
 
@@ -67,24 +61,6 @@ object DdbExprApiSpec extends DynamoDBLocalSpec {
 
   private val envLayer: URLayer[DynamoDbAsyncClient, DynamoDBEnv] =
     ZLayer(ZIO.serviceWith[DynamoDbAsyncClient](client => DynamoDBEnv(client, ZioInterpreter.fromAsyncClient(client))))
-
-  // ── Cross-API helper ──────────────────────────────────────────────────────────
-
-  // Commented out: schema-expr (DdbSchemaExprApi) was removed from the sbt build graph
-  // (deprecated in favor of DdbExprApi). Source kept for reference; not compiled.
-  // Builds a DdbSchemaExprApi scan query in an isolated scope so that its
-  // implicit (SchemaExpr → ConditionExpression) doesn't conflict with the
-  // DdbExprApi implicit (DdbExpr → ConditionExpression) at the call site.
-  // private def schemaExprScan(
-  //   table: String
-  // ): DynamoDBQuery[Task, Page[Either[DynamoDBError.ItemError, Task]]] = {
-  //   import zio.dynamodb.blocks.DdbSchemaExprApi
-  //   import zio.dynamodb.blocks.DdbSchemaExprApi._
-  //   // Task.priority === Priority.High uses ZB's Optic.=== → SchemaExpr[Task, Boolean],
-  //   // which DdbSchemaExprApi implicitly converts to ConditionExpression via DynamicValue.
-  //   // For an all-no-field sealed trait this produces priority = {"High": {}} (wrong).
-  //   DdbSchemaExprApi.scan[Task](table, 10).filter(Task.priority === Priority.High)
-  // }
 
   // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -244,25 +220,6 @@ object DdbExprApiSpec extends DynamoDBLocalSpec {
         }
       }
     )
-
-  // Commented out: depends on schemaExprScan (DdbSchemaExprApi), removed from the sbt
-  // build graph. Source kept for reference; not compiled.
-  // private val crossApiTests: Spec[DynamoDBEnv, Throwable] =
-  //   suite("cross-API encoding mismatch proof")(
-  //     test("DdbExprApi === filter finds item that DdbSchemaExprApi === filter misses") {
-  //       withSingleIdKeyTable { (table, interpreter) =>
-  //         for {
-  //           _          <- interpreter.run(DdbExprApi.put(table, Task("t1", Priority.High)))
-  //           ddbPage    <- interpreter.run(
-  //                           DdbExprApi.scan[Task](table, 10)
-  //                             .filter(Task.priority === Priority.High)
-  //                         )
-  //           schemaPage <- interpreter.run(schemaExprScan(table))
-  //         } yield assertTrue(ddbPage.items.count(_.isRight) == 1) &&
-  //                 assertTrue(schemaPage.items.isEmpty)
-  //       }
-  //     }
-  //   )
 
   private val queryTests: Spec[DynamoDBEnv, Throwable] =
     suite("query with DdbKeyExpr key condition")(
@@ -567,7 +524,6 @@ object DdbExprApiSpec extends DynamoDBLocalSpec {
       compoundKeyTests,
       conditionExprTests,
       enumFilterTests,
-      // crossApiTests, // depends on schemaExprScan (DdbSchemaExprApi), commented out above
       queryTests,
       scanTests,
       updateTests,

--- a/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/DdbExprApi.scala
+++ b/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/DdbExprApi.scala
@@ -27,8 +27,8 @@ import zio.dynamodb.blocks.schema.{ DynamoDBCodec, DynamoDBCodecDeriver }
  * High-level CRUD API backed by [[DdbExpr]] condition expressions and [[DdbKeyExpr]]
  *  key condition expressions.
  *
- *  Unlike the deprecated [[zio.dynamodb.blocks.DdbSchemaExprApi]], all ZB [[zio.blocks.schema.Optic]]
- *  operators (===, >, <, >=, <=) encode sealed-trait literals correctly. Since zio-blocks v0.0.47
+ *  All ZB [[zio.blocks.schema.Optic]] operators (===, >, <, >=, <=) encode sealed-trait
+ *  literals correctly. Since zio-blocks v0.0.47
  *  [[zio.blocks.schema.DynamicSchemaExpr.Literal]] carries a [[zio.blocks.schema.Schema]], the
  *  interpreter derives a [[zio.dynamodb.blocks.schema.DynamoDBCodec]] at evaluation time —
  *  `enumValuesAsStrings` and other encoding rules are preserved automatically.
@@ -67,9 +67,9 @@ object DdbExprApi {
 
   private case class CodecEntry[A](codec: DynamoDBCodec[A], projections: Chunk[ProjectionExpression[_, _]])
 
-  // Keyed by (Schema, DynamoDBCodecDeriverConfigure) reference identity — same
-  // rationale as DdbSchemaExprApi: avoids cross-classloader collisions and ensures
-  // types with custom configures get their own entry.
+  // Keyed by (Schema, DynamoDBCodecDeriverConfigure) reference identity — avoids
+  // cross-classloader collisions and ensures types with custom configures get their
+  // own entry.
   private final class CodecCacheKey(private val r0: AnyRef, private val r1: AnyRef) {
     override val hashCode: Int           = System.identityHashCode(r0) * 31 + System.identityHashCode(r1)
     override def equals(o: Any): Boolean = o match {

--- a/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/DdbExprInterpreter.scala
+++ b/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/DdbExprInterpreter.scala
@@ -115,10 +115,8 @@ object DdbExprInterpreter {
         }
     }
 
-  // Inlined from DdbSchemaExprApi.dynamicToConditionExpression (schema-expr module).
-  // schema-ddbexpr does not depend on schema-expr, so the DynamicSchemaExpr fold
-  // is reproduced here. Both DynamicSchemaExpr (from zio-blocks-schema) and
-  // DynamoDBCodecDeriver.dynamicValueCodec (from schema-dynamodb) are available.
+  // Folds a DynamicSchemaExpr (from zio-blocks-schema) into a ConditionExpression directly;
+  // DynamoDBCodecDeriver.dynamicValueCodec (from schema-dynamodb) is available for encoding.
   private def fromDynamicSchemaExpr[A](dse: DynamicSchemaExpr): ConditionExpression[A] = {
 
     def toRelational(

--- a/schema-dynamodb/src/main/scala/zio/dynamodb/blocks/DynamoDBCodecDeriverConfigure.scala
+++ b/schema-dynamodb/src/main/scala/zio/dynamodb/blocks/DynamoDBCodecDeriverConfigure.scala
@@ -28,7 +28,8 @@ trait DynamoDBCodecDeriverConfigure[+A] {
 
 object DynamoDBCodecDeriverConfigure {
   // Singleton so default[A] always returns the same reference — required for
-  // identity-based cache keys in DdbSchemaExprApi.  Covariance (+A) makes widening safe.
+  // identity-based cache keys (e.g. DdbExprApi's codec cache). Covariance (+A) makes
+  // widening safe.
   private val _identity: DynamoDBCodecDeriverConfigure[Nothing] = d => d
 
   def identity[A]: DynamoDBCodecDeriverConfigure[A]         = _identity


### PR DESCRIPTION
DdbSchemaExprApi (and the schema-expr module it lived in) no longer exists in the repo. Reworded comments that compared against or explained provenance from it, and deleted three fully dead, commented-out blocks in DdbExprApiSpec.scala (schemaExprScan helper, crossApiTests suite, and its entry in the spec composition) that only existed to reference it.