### PR TITLE
Fix decoder state-reuse bug in vanilla record and tuple codecs

### DIFF
--- a/schema-dynamodb/src/main/scala/zio/dynamodb/blocks/schema/DynamoDBCodecDeriver.scala
+++ b/schema-dynamodb/src/main/scala/zio/dynamodb/blocks/schema/DynamoDBCodecDeriver.scala
@@ -509,7 +509,7 @@ class DynamoDBCodecDeriver private (
             else AttributeValue.List(scala.collection.immutable.ArraySeq.unsafeWrapArray(arr))
           }
 
-          override def decoder: Decoder[A] = {
+          override def decoder: Decoder[A] = { (av: AttributeValue) =>
             val regs                 = Registers(usedRegisters)
             var error: DecodingError = null
 
@@ -599,29 +599,28 @@ class DynamoDBCodecDeriver private (
 
             }
 
-            (av: AttributeValue) =>
-              av match {
-                case avList: AttributeValue.List =>
-                  val it  = avList.value.iterator
-                  var idx = 0
-                  while (it.hasNext && idx < len) {
-                    val field = fieldInfos(idx)
-                    val value = it.next()
+            av match {
+              case avList: AttributeValue.List =>
+                val it  = avList.value.iterator
+                var idx = 0
+                while (it.hasNext && idx < len) {
+                  val field = fieldInfos(idx)
+                  val value = it.next()
 
-                    setValue(field, value)
-                    idx += 1
-                  } // end while
-                  if (error == null) {
-                    val a = constructor.construct(regs, RegisterOffset.Zero)
-                    Right(a)
-                  } else if (schema1TupleCompat != Schema1Compat.ReadNewWriteNew) {
-                    error = null
-                    decodeLegacy(avList)
-                  } else
-                    Left(error)
-                case av: AttributeValue          =>
-                  Left(DecodingError(s"Expected List attribute value but got: ${av.showType}"))
-              }
+                  setValue(field, value)
+                  idx += 1
+                } // end while
+                if (error == null) {
+                  val a = constructor.construct(regs, RegisterOffset.Zero)
+                  Right(a)
+                } else if (schema1TupleCompat != Schema1Compat.ReadNewWriteNew) {
+                  error = null
+                  decodeLegacy(avList)
+                } else
+                  Left(error)
+              case av: AttributeValue          =>
+                Left(DecodingError(s"Expected List attribute value but got: ${av.showType}"))
+            }
           }
         }
       }
@@ -789,15 +788,16 @@ class DynamoDBCodecDeriver private (
             }
 
             override def decoder: Decoder[A] = {
-              val len                  = fields.length
-              var idx                  = 0
-              val regs                 = Registers(usedRegisters)
-              var error: DecodingError = null
+              val len = fields.length
 
-              def accumulate(e: DecodingError): Unit =
-                error = if (error == null) e else error ++ e
+              (av: AttributeValue) => {
+                var idx                  = 0
+                val regs                 = Registers(usedRegisters)
+                var error: DecodingError = null
 
-              (av: AttributeValue) =>
+                def accumulate(e: DecodingError): Unit =
+                  error = if (error == null) e else error ++ e
+
                 av match {
                   case avMap: AttributeValue.Map =>
                     if (knownFields ne null) {
@@ -881,6 +881,7 @@ class DynamoDBCodecDeriver private (
                   case av: AttributeValue =>
                     Left(DecodingError(s"Expected Map attribute value but got: ${av.showType}"))
                 }
+              }
             }
           } // end if else not tuple
         }

--- a/schema-dynamodb/src/test/scala/zio/dynamodb/blocks/schema/DynamoDBCodecDeriverSpec.scala
+++ b/schema-dynamodb/src/test/scala/zio/dynamodb/blocks/schema/DynamoDBCodecDeriverSpec.scala
@@ -644,6 +644,18 @@ object DynamoDBCodecDeriverSpec extends ZIOSpecDefault {
             hasField("payload", (_: BinaryPayload).payload.toList, equalTo(record.payload.toList))
         )
       )
+    },
+    test("decoder is safe to reuse across multiple decode calls") {
+      // Regression: idx/regs/error used to be allocated outside the returned decoder
+      // function, so a decoder captured once and invoked repeatedly (a natural thing to
+      // do to avoid re-fetching `codec.decoder` per call) silently returned the first
+      // call's result on every subsequent call.
+      val codec  = codecFor[Person]
+      val decode = codec.decoder
+      val r1     = decode(codec.encoder(Person("Alice", 30)))
+      val r2     = decode(codec.encoder(Person("Bob", 25)))
+      val r3     = decode(codec.encoder(Person("Alice", 30)))
+      assertTrue(r1 == Right(Person("Alice", 30)), r2 == Right(Person("Bob", 25)), r3 == Right(Person("Alice", 30)))
     }
   )
 
@@ -2267,6 +2279,17 @@ object DynamoDBCodecDeriverSpec extends ZIOSpecDefault {
       val codec = codecFor[(Int, Long, Boolean, Byte, Char, Short, Float, Double)]
       val value = (1, 2L, true, 3.toByte, 'c', 4.toShort, 5.5f, 6.6)
       assertTrue(codec.decoder(codec.encoder(value)) == Right(value))
+    },
+    test("decoder is safe to reuse across multiple decode calls") {
+      // Regression: the tuple decoder's regs/error were allocated outside the returned
+      // decoder function, mirroring the same bug as the vanilla record decoder — a
+      // captured decoder reused across calls would silently return stale results.
+      val codec  = tupleCodecForNew[(String, Int)]
+      val decode = codec.decoder
+      val r1     = decode(codec.encoder(("a", 1)))
+      val r2     = decode(codec.encoder(("b", 2)))
+      val r3     = decode(codec.encoder(("a", 1)))
+      assertTrue(r1 == Right(("a", 1)), r2 == Right(("b", 2)), r3 == Right(("a", 1)))
     }
   )
 


### PR DESCRIPTION
Registers/error/idx were allocated outside the returned Decoder[A] closure, so a decoder captured once (e.g. `val d = codec.decoder`) and invoked more than once silently returned the first call's result on every subsequent call instead of decoding its actual input. Moving the mutable state inside the closure so each invocation gets fresh state.