### PR TITLE
Fix genericRecordDecoder missing-field handling for all container types

### DIFF
--- a/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
@@ -687,22 +687,21 @@ private[dynamodb] object Codec {
           case AttributeValue.Map(map) =>
             structure.toChunk.forEach {
               case Schema.Field(key, schema, _, _, _, _) =>
-                val dec          = decoder(schema)
-                val k            = key // @fieldName is respected by the zio-schema macro
-                val maybeAv      = map.get(AttributeValue.String(k))
-                val errorOrValue =
-                  maybeAv.toRight(DecodingError(s"field '$k' not found in AttributeValue map")).flatMap(dec)
-                if (maybeAv.isEmpty)
-                  ContainerField.containerField(schema) match {
-                    case ContainerField.Optional => Right(k -> None)
-                    case ContainerField.Chunk    => Right(k -> Chunk.empty)
-                    case ContainerField.Sequence => Right(k -> List.empty)
-                    case ContainerField.Map      => Right(k -> Map.empty)
-                    case ContainerField.Set      => Right(k -> Set.empty)
-                    case ContainerField.Scalar   => errorOrValue.map(k -> _)
-                  }
-                else
-                  errorOrValue.map(k -> _)
+                val k = key // @fieldName is respected by the zio-schema macro
+                map.get(AttributeValue.String(k)) match {
+                  case Some(av) =>
+                    decoder(schema)(av).map(k -> _)
+                  case None     =>
+                    ContainerField.containerField(schema) match {
+                      case ContainerField.Optional => Right(k -> None)
+                      case ContainerField.Chunk    => Right(k -> Chunk.empty)
+                      case ContainerField.Sequence => Right(k -> List.empty)
+                      case ContainerField.Map      => Right(k -> Map.empty)
+                      case ContainerField.Set      => Right(k -> Set.empty)
+                      case ContainerField.Scalar   =>
+                        Left(DecodingError(s"field '$k' not found in AttributeValue map"))
+                    }
+                }
             }
               .map(ls => ListMap.newBuilder.++=(ls).result())
           case av                      => Left(DecodingError(s"Expected AttributeValue.Map but found ${av.showType}"))

--- a/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/Codec.scala
@@ -686,16 +686,23 @@ private[dynamodb] object Codec {
         av match {
           case AttributeValue.Map(map) =>
             structure.toChunk.forEach {
-              case Schema.Field(key, schema: Schema[a], _, _, _, _) =>
-                map.get(AttributeValue.String(key)) match {
-                  case Some(av) =>
-                    val dec = decoder(schema)
-                    dec(av) match {
-                      case Right(value) => Right(key -> value)
-                      case Left(s)      => Left(s)
-                    }
-                  case None     => Right(key -> None)
-                }
+              case Schema.Field(key, schema, _, _, _, _) =>
+                val dec          = decoder(schema)
+                val k            = key // @fieldName is respected by the zio-schema macro
+                val maybeAv      = map.get(AttributeValue.String(k))
+                val errorOrValue =
+                  maybeAv.toRight(DecodingError(s"field '$k' not found in AttributeValue map")).flatMap(dec)
+                if (maybeAv.isEmpty)
+                  ContainerField.containerField(schema) match {
+                    case ContainerField.Optional => Right(k -> None)
+                    case ContainerField.Chunk    => Right(k -> Chunk.empty)
+                    case ContainerField.Sequence => Right(k -> List.empty)
+                    case ContainerField.Map      => Right(k -> Map.empty)
+                    case ContainerField.Set      => Right(k -> Set.empty)
+                    case ContainerField.Scalar   => errorOrValue.map(k -> _)
+                  }
+                else
+                  errorOrValue.map(k -> _)
             }
               .map(ls => ListMap.newBuilder.++=(ls).result())
           case av                      => Left(DecodingError(s"Expected AttributeValue.Map but found ${av.showType}"))

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/CodecRoundTripSpec.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/CodecRoundTripSpec.scala
@@ -1,8 +1,9 @@
 package zio.dynamodb.codec
 
 import zio.dynamodb.{ AttributeValue, Codec, DynamoDBQuery }
+import zio.dynamodb.DynamoDBError.ItemError.DecodingError
 import zio.schema.{ DeriveSchema, Schema, StandardType }
-import zio.test.Assertion.{ equalTo, isRight }
+import zio.test.Assertion.{ equalTo, isLeft, isRight }
 import zio.test._
 import zio.{ Chunk, ZIO }
 
@@ -25,7 +26,8 @@ object CodecRoundTripSpec extends ZIOSpecDefault with CodecTestFixtures {
       enumerationSuite,
       transformSuite,
       anySchemaSuite,
-      bigSchemaSuite
+      bigSchemaSuite,
+      genericRecordMissingFieldSuite
     )
 
   private val eitherSuite = suite("either suite")(
@@ -397,6 +399,84 @@ object CodecRoundTripSpec extends ZIOSpecDefault with CodecTestFixtures {
       )
     }
   )
+
+  // Follow-up to PR #712 (github.com/zio/zio-dynamodb/pull/712): genericRecordDecoder now
+  // mirrors decodeFields's full ContainerField match for a missing field, instead of only
+  // special-casing Optional. One fixture with one field per ContainerField tier
+  // (genericRecordAllContainerFieldsSchema, from CodecTestFixtures) exercises
+  // genericRecordDecoder directly; the Big/BigList pair separately proves the fix also
+  // applies to the more mainstream, easy-to-miss trigger: any ordinary case class with more
+  // than 22 fields, where zio-schema's own derivation macro silently falls back to
+  // Schema.GenericRecord (CaseClassN stops at 22).
+  private val genericRecordMissingFieldSuite = {
+    val scalarField   = toAvString("scalarField")   -> toAvString("hello")
+    val optionalField = toAvString("optionalField") -> toAvString("present")
+    val chunkField    = toAvString("chunkField")    -> AttributeValue.List(Chunk(toAvString("a")))
+    val listField     = toAvString("listField")     -> AttributeValue.List(Chunk(toAvString("b")))
+    val mapField      = toAvString("mapField")      -> AttributeValue.Map(Map(toAvString("k") -> toAvNum(1)))
+    val setField      = toAvString("setField")      -> AttributeValue.StringSet(Set("x"))
+
+    val allFields = Map(scalarField, optionalField, chunkField, listField, mapField, setField)
+
+    def itemExcluding(key: String): AttributeValue.Map =
+      AttributeValue.Map(allFields - toAvString(key))
+
+    val expectedAllPresent: ListMap[String, _] = ListMap(
+      "scalarField"   -> "hello",
+      "optionalField" -> Some("present"),
+      "chunkField"    -> Chunk("a"),
+      "listField"     -> List("b"),
+      "mapField"      -> Map("k" -> 1),
+      "setField"      -> Set("x")
+    )
+
+    def decode(item: AttributeValue.Map) = Codec.decoder(genericRecordAllContainerFieldsSchema)(item)
+
+    suite("genericRecordDecoder missing-field handling (PR #712 follow-up)")(
+      test("all fields present decodes normally") {
+        assertTrue(decode(AttributeValue.Map(allFields)) == Right(expectedAllPresent))
+      },
+      test("missing scalarField (Scalar) fails with a decode error, not a silent bad value") {
+        assert(decode(itemExcluding("scalarField")))(
+          isLeft(equalTo(DecodingError("field 'scalarField' not found in AttributeValue map")))
+        )
+      },
+      test("missing optionalField (Optional) decodes to None") {
+        assertTrue(decode(itemExcluding("optionalField")) == Right(expectedAllPresent.updated("optionalField", None)))
+      },
+      test("missing chunkField (Chunk) decodes to Chunk.empty, not an error") {
+        assertTrue(decode(itemExcluding("chunkField")) == Right(expectedAllPresent.updated("chunkField", Chunk.empty)))
+      },
+      test("missing listField (Sequence) decodes to Nil, not an error") {
+        assertTrue(decode(itemExcluding("listField")) == Right(expectedAllPresent.updated("listField", Nil)))
+      },
+      test("missing mapField (Map) decodes to Map.empty, not an error") {
+        assertTrue(decode(itemExcluding("mapField")) == Right(expectedAllPresent.updated("mapField", Map.empty)))
+      },
+      test("missing setField (Set) decodes to Set.empty, not an error") {
+        assertTrue(decode(itemExcluding("setField")) == Right(expectedAllPresent.updated("setField", Set.empty)))
+      },
+      test(
+        "missing List-typed fields on a >22-field case class (arity-triggered GenericRecord fallback) decode to Nil"
+      ) {
+        // format: off
+        val big = Big(
+          "id", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10",
+          "f11", "f12", "f13", "f14", "f15", "f16", "f17", None, None,
+          None, None, None, None, None, None, None, None, None, None, None
+        )
+        val expected = BigList(
+          "id", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10",
+          "f11", "f12", "f13", "f14", "f15", "f16", "f17", Nil, Nil,
+          Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil, Nil
+        )
+        // format: on
+        val item     = DynamoDBQuery.toItem(big)
+        val decoded  = DynamoDBQuery.fromItem[BigList](item)
+        assert(decoded)(isRight(equalTo(expected)))
+      }
+    )
+  }
 
   private def assertEncodesThenDecodesWithGen[A](schema: Schema[A], genA: Gen[Sized, A]) =
     check(genA) { a =>

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/CodecTestFixtures.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/CodecTestFixtures.scala
@@ -27,6 +27,49 @@ trait CodecTestFixtures {
       )
   )
 
+  // One field per ContainerField tier (Optional/Chunk/Sequence/Map/Set/Scalar) — used to
+  // exercise genericRecordDecoder's missing-field handling for every tier directly, without
+  // needing a >22-field case class to force the GenericRecord fallback.
+  val genericRecordAllContainerFieldsSchema: Schema[ListMap[String, _]] = Schema.record(
+    TypeId.Structural,
+    Schema.Field(
+      "scalarField",
+      Schema.Primitive(StandardType.StringType),
+      get0 = (p: ListMap[String, _]) => p("scalarField").asInstanceOf[String],
+      set0 = (p: ListMap[String, _], v: String) => p.updated("scalarField", v)
+    ),
+    Schema.Field(
+      "optionalField",
+      Schema.Optional(Schema.Primitive(StandardType.StringType)),
+      get0 = (p: ListMap[String, _]) => p("optionalField").asInstanceOf[Option[String]],
+      set0 = (p: ListMap[String, _], v: Option[String]) => p.updated("optionalField", v)
+    ),
+    Schema.Field(
+      "chunkField",
+      Schema.chunk(Schema.Primitive(StandardType.StringType)),
+      get0 = (p: ListMap[String, _]) => p("chunkField").asInstanceOf[zio.Chunk[String]],
+      set0 = (p: ListMap[String, _], v: zio.Chunk[String]) => p.updated("chunkField", v)
+    ),
+    Schema.Field(
+      "listField",
+      Schema.list(Schema.Primitive(StandardType.StringType)),
+      get0 = (p: ListMap[String, _]) => p("listField").asInstanceOf[List[String]],
+      set0 = (p: ListMap[String, _], v: List[String]) => p.updated("listField", v)
+    ),
+    Schema.Field(
+      "mapField",
+      Schema.map(Schema.Primitive(StandardType.StringType), Schema.Primitive(StandardType.IntType)),
+      get0 = (p: ListMap[String, _]) => p("mapField").asInstanceOf[Map[String, Int]],
+      set0 = (p: ListMap[String, _], v: Map[String, Int]) => p.updated("mapField", v)
+    ),
+    Schema.Field(
+      "setField",
+      Schema.set(Schema.Primitive(StandardType.StringType)),
+      get0 = (p: ListMap[String, _]) => p("setField").asInstanceOf[Set[String]],
+      set0 = (p: ListMap[String, _], v: Set[String]) => p.updated("setField", v)
+    )
+  )
+
   val enumSchema: Schema[Any] = Schema.enumeration[Any, CaseSet.Aux[Any]](
     TypeId.Structural,
     caseOf[String, Any]("string")(_.asInstanceOf[String])(_.asInstanceOf[Any])(_.isInstanceOf[String]) ++ caseOf[

--- a/dynamodb/src/test/scala/zio/dynamodb/codec/models.scala
+++ b/dynamodb/src/test/scala/zio/dynamodb/codec/models.scala
@@ -215,3 +215,18 @@ object Big {
 
   val id: ProjectionExpression[Big, String] = ProjectionExpression.$$("id")
 }
+
+// Same 32-field shape as Big (arity > 22, so DeriveSchema.gen falls back to a
+// Schema.GenericRecord under the hood) but with the trailing fields typed as List[String]
+// instead of Option[String], to exercise genericRecordDecoder's missing-Sequence-field path.
+// format: off
+case class BigList(
+  id: String, f0: String, f1: String, f2: String, f3: String, f4: String, f5: String, f6: String, f7: String, f8: String, f9: String,
+  f10: String, f11: String, f12: String, f13: String, f14: String, f15: String, f16: String, f17: String, f18: List[String], f19: List[String],
+  f20: List[String], f21: List[String], f22: List[String], f23: List[String], f24: List[String], f25: List[String], f26: List[String], f27: List[String],
+  f28: List[String], f29: List[String], f30: List[String],
+)
+// format: on
+object BigList {
+  implicit val schema: Schema[BigList] = DeriveSchema.gen[BigList]
+}


### PR DESCRIPTION
Follow-up to #712 (@googley42's suggestion on #701): genericRecordDecoder only special-cased Optional for a missing field, falling through to a DecodingError for Chunk/Sequence/Map/Set instead of the empty-collection default decodeFields already produces for the same shapes. Mirrors decodeFields's full ContainerField match instead, reusing #701's ContainerField.containerField(schema) as-is.

Also covers the more mainstream trigger for Schema.GenericRecord: any case class with more than 22 fields, where zio-schema's own derivation macro silently falls back to GenericRecord past its CaseClass22 ceiling (confirmed by reading DeriveSchema.scala:331,384). The existing Big/ BigList-style fixture now proves the fix holds under that trigger too, not just for hand-built Schema.record schemas.