### PR TITLE
Fix Scala 3.10 implicit-accessibility deprecation for partitionKey/so…

### DIFF
--- a/dynamodb/src/main/scala/zio/dynamodb/PartitionKey.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/PartitionKey.scala
@@ -4,7 +4,7 @@ import zio.dynamodb.KeyConditionExpr.PartitionKeyEquals
 import zio.dynamodb.ProjectionExpression.Unknown
 
 private[dynamodb] final case class PartitionKey[-From, +To](keyName: String)
-private[dynamodb] object PartitionKey {
+object PartitionKey {
   implicit class PartitionKeyUnknownToOps[-From](val pk: PartitionKey[From, Unknown])         {
     def ===[To: ToAttributeValue](
       value: To

--- a/dynamodb/src/main/scala/zio/dynamodb/SortKey.scala
+++ b/dynamodb/src/main/scala/zio/dynamodb/SortKey.scala
@@ -8,7 +8,7 @@ import zio.dynamodb.ProjectionExpression.Unknown
 
 private[dynamodb] final case class SortKey[-From, +To](keyName: String)
 
-private[dynamodb] object SortKey {
+object SortKey {
   // all comparison ops apply to: Strings, Numbers, Binary values
 
   implicit class SortKeyUnknownToOps[-From](val sk: SortKey[From, Unknown]) {


### PR DESCRIPTION
…rtKey ops

Fixes #909. PartitionKey/SortKey's companion objects were private[dynamodb], so the implicit classes providing ===, >, <, between, beginsWith etc. were only reachable from outside the package via Scala's implicit-scope lookup leniency around inaccessible implicits — a leniency Scala 3.8.4+ now warns about ("this implicit will no longer be found" in 3.10) and 3.10 will turn into a hard compile error.

Dropping private[dynamodb] from just the two companion objects (the case classes themselves stay private, so direct construction is still not part of the public API) restores real accessibility for the implicit classes. Verified against a real Scala 3.8.4 compiler using a locally published snapshot: the reporter's exact repro produces the deprecation warning before this change and not after, with no other warnings introduced.