### PR TITLE
Match both Scala Steward logins in the bot workflows

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -21,7 +21,7 @@ jobs:
     name: auto-approve-bot-prs
     runs-on: ubuntu-latest
     continue-on-error: false
-    if: ${{ (((github.event_name == 'workflow_dispatch') || (github.event.pull_request.user.login == 'dependabot[bot]')) || (github.event.pull_request.user.login == 'renovate[bot]')) || (github.event.pull_request.user.login == 'scala-steward') }}
+    if: ${{ ((((github.event_name == 'workflow_dispatch') || (github.event.pull_request.user.login == 'dependabot[bot]')) || (github.event.pull_request.user.login == 'renovate[bot]')) || (github.event.pull_request.user.login == 'zio-scala-steward[bot]')) || (github.event.pull_request.user.login == 'scala-steward') }}
     steps:
     - name: Approve PR
       if: ${{ github.event_name == 'pull_request_target' }}
@@ -33,7 +33,7 @@ jobs:
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
         set -euo pipefail
-        for actor in "dependabot[bot]" "renovate[bot]" "scala-steward"; do
+        for actor in "dependabot[bot]" "renovate[bot]" "zio-scala-steward[bot]" "scala-steward"; do
           gh pr list \
             --author "$actor" \
             --state open \

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,7 +23,7 @@ jobs:
     name: auto-merge
     runs-on: ubuntu-latest
     continue-on-error: false
-    if: ${{ (((github.event_name == 'workflow_dispatch') || (github.event.pull_request.user.login == 'dependabot[bot]')) || (github.event.pull_request.user.login == 'renovate[bot]')) || (github.event.pull_request.user.login == 'scala-steward') }}
+    if: ${{ ((((github.event_name == 'workflow_dispatch') || (github.event.pull_request.user.login == 'dependabot[bot]')) || (github.event.pull_request.user.login == 'renovate[bot]')) || (github.event.pull_request.user.login == 'zio-scala-steward[bot]')) || (github.event.pull_request.user.login == 'scala-steward') }}
     steps:
     - name: Enable auto-merge for bot PR
       if: ${{ github.event_name == 'pull_request_target' }}
@@ -35,7 +35,7 @@ jobs:
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
         set -euo pipefail
-        for actor in "dependabot[bot]" "renovate[bot]" "scala-steward"; do
+        for actor in "dependabot[bot]" "renovate[bot]" "zio-scala-steward[bot]" "scala-steward"; do
           gh pr list \
             --author "$actor" \
             --state open \

--- a/build.sbt
+++ b/build.sbt
@@ -31,11 +31,13 @@ inThisBuild(
     ciDefaultJavaVersion := "17",
     ciTargetJavaVersions := Seq("17", "21", "25"),
     ciJvmOptions := Seq("-XX:+UseG1GC", "-Xmx6g", "-Xms6g", "-Xss16m"),
-    // This repository's Scala Steward runs as the plain `scala-steward` account, not as the
-    // `zio-scala-steward[bot]` GitHub App the plugin defaults to.
+    // This repository's Scala Steward currently runs as the plain `scala-steward` account rather
+    // than as the `zio-scala-steward[bot]` GitHub App the plugin defaults to. Both are listed so
+    // that moving the repository onto the app does not silently stop matching its PRs.
     ciDependencyUpdateBots := Seq(
       DependencyBot.Dependabot,
       DependencyBot.Renovate,
+      DependencyBot.ScalaSteward("zio-scala-steward"),
       DependencyBot.Custom("scala-steward")
     ),
     // The plugin marks the build job `continue-on-error`. Documentation compilation used to be a


### PR DESCRIPTION
Follow-up to #924, which added the generated `auto-approve.yml` and `auto-merge.yml`.

Those workflows currently match `scala-steward`, the plain account that authors dependency PRs on this repository. The zio organisation also runs Scala Steward as the `zio-scala-steward` GitHub App, which zio/zio, zio/zio-sbt and zio/zio-http all use, and whose PRs arrive under the `zio-scala-steward[bot]` login instead.

If this repository is ever moved onto the app, matching only the account would stop the auto-approve and auto-merge workflows from recognising its PRs. Nothing would fail — the workflows would run, match nothing and quietly do nothing — so the regression would be easy to miss. Listing both logins means it keeps working either way.

Set via `ciDependencyUpdateBots` in `build.sbt`; the two workflow files are regenerated output.

```
for actor in "dependabot[bot]" "renovate[bot]" "zio-scala-steward[bot]" "scala-steward"; do
```

`ci.yml` is unaffected — the bot list feeds only the two bot workflows.

## Verified

`sbt ciGenerateGithubWorkflow` reproduces the committed files exactly from this base, so the `lint` job's `ciCheckGithubWorkflow` check passes. `sbt lint` passes.
