### PR TITLE
Ignore the mdoc output directory website/docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -466,6 +466,7 @@ project/secret
 project/metals.sbt
 
 # mdoc
+website/docs
 website/node_modules
 website/build
 website/i18n/en.json


### PR DESCRIPTION
## Problem

The `build` job fails on the generated README pull request — see [#930](https://github.com/zio/zio-dynamodb/pull/930), [failing job](https://github.com/zio/zio-dynamodb/actions/runs/32409412124/job/96556078264):

```
npm error path /home/runner/work/zio-dynamodb/zio-dynamodb/website/package.json
npm error enoent Could not read package.json
[error] java.lang.RuntimeException: Failed to install website dependencies!
	at zio.sbt.WebsitePlugin$.$anonfun$buildWebsiteTask$1(WebsitePlugin.scala:265)
```

The `update-readme` job runs `sbt docs/generateReadme`, which runs `compileDocs` and therefore writes mdoc output to `website/docs` — `mdocOut` is defined as `websiteDir.value.resolve("docs")`. That path was not ignored, so `peter-evans/create-pull-request` committed the directory into the pull request alongside `README.md`. The head commit of #930 contains a `website/docs` tree.

On a pull request carrying that directory, `installWebsite` skips scaffolding:

```scala
if (Files.exists(websiteDirPath)) {
  logger.warn("Website directory already exists, skipping installation")
}
```

so Docusaurus is never installed and no `package.json` is written. The recovery path in `buildWebsite` then assumes a complete, committed website whose dependencies merely need installing:

```scala
// The website directory may already exist (e.g. committed to the repository) so
// installWebsiteTask skips installation, but its dependencies are not versioned.
if (!Files.exists(websiteDir.value.resolve("node_modules")))
  exit(Process("npm install", ...).!, "Failed to install website dependencies!")
```

The directory holds only mdoc output, so `npm install` has no `package.json` to read and fails with ENOENT.

This is not related to the zio-sbt 0.7.0 bump: `series/2.x` at 0.7.0 passed six minutes earlier ([run 32408854428](https://github.com/zio/zio-dynamodb/actions/runs/32408854428)), and the workflow step is byte-identical to the one 0.6.3 generated. The only difference is the stray directory in the pull request.

## Fix

Add `website/docs` to `.gitignore`.

The existing narrower entries are kept as they are. Only the mdoc output is generated on this path, and ignoring `website/` wholesale would prevent committing website customisations later — which the plugin explicitly supports, per the comment quoted above.

## Verified

`sbt docs/compileDocs` regenerates `website/docs`, and `git status` no longer reports it. Before this change the same command left an untracked `website/`, which is what `create-pull-request` was picking up.

Once this merges, #930 needs closing and regenerating — its head commit still carries the committed directory, so re-running CI on it as-is would fail the same way.

## Worth fixing upstream too

Every ZIO repository whose `.gitignore` does not already cover this path has the same latent failure. Filed as [zio/zio-sbt#749](https://github.com/zio/zio-sbt/issues/749): scoping `create-pull-request` to `README.md` via its `add-paths` input would fix the class of problem rather than each instance.

