### PR TITLE
Fail .where/.filter/.whereKey on unsupported query types instead of s…

### DIFF
--- a/core/src/main/scala/zio/dynamodb/DynamoDBError.scala
+++ b/core/src/main/scala/zio/dynamodb/DynamoDBError.scala
@@ -26,12 +26,13 @@ import scala.util.control.NoStackTrace
  * rather than exceptional JVM conditions — a stack trace would be noise, not signal.
  *
  * Sealed subtrees: [[DynamoDBError.ItemError]] (single-item decode/lookup failures),
- * [[DynamoDBError.ScanError]] (scan/query validation), and
+ * [[DynamoDBError.ScanError]] (scan/query validation),
  * [[DynamoDBError.TransactionError]] (`transactWriteItems`/`transactGetItems` failures,
  * including [[DynamoDBError.TransactionError.TransactionCancelled]]'s per-item
- * [[DynamoDBError.CancellationReason]]s). Batch operations deliberately don't raise
- * `DynamoDBError` for partial failure — see `Batch.GetResult`/`Batch.WriteResult`'s
- * errors-as-values design instead.
+ * [[DynamoDBError.CancellationReason]]s), and [[DynamoDBError.QueryBuilderError]] (a builder
+ * modifier applied to a `DynamoDBQuery` variant that doesn't support it, e.g. `.where` on a
+ * scan). Batch operations deliberately don't raise `DynamoDBError` for partial failure — see
+ * `Batch.GetResult`/`Batch.WriteResult`'s errors-as-values design instead.
  */
 sealed trait DynamoDBError extends Throwable with NoStackTrace with Product with Serializable {
   def message: String
@@ -39,8 +40,9 @@ sealed trait DynamoDBError extends Throwable with NoStackTrace with Product with
 }
 
 /**
- * The three [[DynamoDBError]] subtrees ([[DynamoDBError.ItemError]],
- * [[DynamoDBError.ScanError]], [[DynamoDBError.TransactionError]]) and their cases.
+ * The four [[DynamoDBError]] subtrees ([[DynamoDBError.ItemError]],
+ * [[DynamoDBError.ScanError]], [[DynamoDBError.TransactionError]],
+ * [[DynamoDBError.QueryBuilderError]]) and their cases.
  */
 object DynamoDBError {
 
@@ -50,6 +52,20 @@ object DynamoDBError {
 
   object ScanError {
     final case class ScanValidationError(message: String) extends ScanError
+  }
+
+  /**
+   * Raised when a `DynamoDBQuery` builder modifier is applied to a query variant that doesn't
+   *  support it — e.g. `.where` (condition expressions) on a `scanSome`/`querySome`, or
+   *  `.filter` (filter expressions) on a `putItem`/`updateItem`/`deleteItem`. The query still
+   *  builds successfully (this is only raised once the resulting query is executed) — the
+   *  modifier call itself just becomes a [[DynamoDBQuery.Fail]] carrying this error, rather
+   *  than silently returning the original query unchanged.
+   */
+  sealed trait QueryBuilderError extends DynamoDBError
+
+  object QueryBuilderError {
+    final case class UnsupportedModifier(message: String) extends QueryBuilderError
   }
 
   sealed trait TransactionError extends DynamoDBError

--- a/core/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
+++ b/core/src/main/scala/zio/dynamodb/DynamoDBQuery.scala
@@ -84,7 +84,13 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
         u.copy(conditionExpression = Some(conditionExpression)).asInstanceOf[DynamoDBQuery[In, Out]]
       case d: DynamoDBQuery.DeleteItem            =>
         d.copy(conditionExpression = Some(conditionExpression)).asInstanceOf[DynamoDBQuery[In, Out]]
-      case _                                      => self
+      case _                                      =>
+        DynamoDBQuery.fail(
+          DynamoDBError.QueryBuilderError.UnsupportedModifier(
+            s"'.where' has no effect on ${self.getClass.getSimpleName}; condition expressions are only " +
+              s"supported on putItem/updateItem/deleteItem — did you mean '.filter'?"
+          )
+        )
     }
   }
 
@@ -107,7 +113,13 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
 
       case s: DynamoDBQuery.QuerySome =>
         s.copy(keyConditionExpr = Some(keyConditionExpression)).asInstanceOf[DynamoDBQuery[In, Out]]
-      case _                          => self
+      case _                          =>
+        DynamoDBQuery.fail(
+          DynamoDBError.QueryBuilderError.UnsupportedModifier(
+            s"'.whereKey' has no effect on ${self.getClass.getSimpleName}; key condition expressions are " +
+              s"only supported on querySome"
+          )
+        )
     }
 
   final def returnValuesOnConditionCheckFailure(
@@ -179,7 +191,13 @@ sealed trait DynamoDBQuery[-In, +Out] { self =>
         s.copy(filterExpression = Some(filterExpression)).asInstanceOf[DynamoDBQuery[In, Out]]
       case s: DynamoDBQuery.QuerySome =>
         s.copy(filterExpression = Some(filterExpression)).asInstanceOf[DynamoDBQuery[In, Out]]
-      case _                          => self
+      case _                          =>
+        DynamoDBQuery.fail(
+          DynamoDBError.QueryBuilderError.UnsupportedModifier(
+            s"'.filter' has no effect on ${self.getClass.getSimpleName}; filter expressions are only " +
+              s"supported on scanSome/querySome — did you mean '.where'?"
+          )
+        )
     }
   }
 

--- a/core/src/test/scala/zio/dynamodb/MiscSpec.scala
+++ b/core/src/test/scala/zio/dynamodb/MiscSpec.scala
@@ -17,7 +17,7 @@
 package zio.dynamodb
 
 import zio.test._
-import zio.test.Assertion.{ anything, isSubtype }
+import zio.test.Assertion.{ anything, containsString, hasField, isSubtype }
 
 object MiscSpec extends ZIOSpecDefault {
 
@@ -181,11 +181,15 @@ object MiscSpec extends ZIOSpecDefault {
       val withKey = absolve.whereKey(pk === "val")
       assertTrue(withKey != null)
     },
-    test("whereKey on non-QuerySome returns self unchanged") {
+    test("whereKey on non-QuerySome fails with QueryBuilderError") {
       val q      = DynamoDBQuery.GetItem("t", PrimaryKey("id" -> "1"))
       val pk     = ProjectionExpression.$("id").partitionKey
       val result = q.whereKey(pk === "val")
-      assertTrue(result == q)
+      assert(result)(
+        isSubtype[DynamoDBQuery.Fail](
+          hasField("error", _.error(), isSubtype[DynamoDBError.QueryBuilderError.UnsupportedModifier](anything))
+        )
+      )
     },
     test("where on ZipPar propagates condition to both branches") {
       val q1                             = DynamoDBQuery.putItem("t1", Item("id" -> "1"))
@@ -209,11 +213,31 @@ object MiscSpec extends ZIOSpecDefault {
       val result                         = q.where(cond)
       assertTrue(result != null)
     },
-    test("where on non-matching query returns self") {
+    test("where on non-matching query fails with QueryBuilderError") {
       val q                              = DynamoDBQuery.GetItem("t", PrimaryKey("id" -> "1"))
       val cond: ConditionExpression[Any] = ProjectionExpression.$("id") === "1"
       val result                         = q.where(cond)
-      assertTrue(result == q)
+      assert(result)(
+        isSubtype[DynamoDBQuery.Fail](
+          hasField("error", _.error(), isSubtype[DynamoDBError.QueryBuilderError.UnsupportedModifier](anything))
+        )
+      )
+    },
+    test("where on scanSome fails with a message suggesting '.filter' (issue #748)") {
+      val q                              = DynamoDBQuery.scanSome("t", 10)
+      val cond: ConditionExpression[Any] = ProjectionExpression.$("id") === "1"
+      val result                         = q.where(cond)
+      assert(result)(
+        isSubtype[DynamoDBQuery.Fail](
+          hasField(
+            "error",
+            _.error(),
+            isSubtype[DynamoDBError.QueryBuilderError.UnsupportedModifier](
+              hasField("message", _.message, containsString("'.filter'"))
+            )
+          )
+        )
+      )
     },
     test("filter on ZipPar propagates filter to both branches") {
       val q1                          = DynamoDBQuery.QuerySome("t1", 10)
@@ -223,11 +247,31 @@ object MiscSpec extends ZIOSpecDefault {
       val withFilter                  = zipped.filter(filt)
       assertTrue(withFilter != null)
     },
-    test("filter on non-matching query returns self") {
+    test("filter on non-matching query fails with QueryBuilderError") {
       val q                           = DynamoDBQuery.GetItem("t", PrimaryKey("id" -> "1"))
       val filt: FilterExpression[Any] = ProjectionExpression.$("name") === "alice"
       val result                      = q.filter(filt)
-      assertTrue(result == q)
+      assert(result)(
+        isSubtype[DynamoDBQuery.Fail](
+          hasField("error", _.error(), isSubtype[DynamoDBError.QueryBuilderError.UnsupportedModifier](anything))
+        )
+      )
+    },
+    test("filter on putItem fails with a message suggesting '.where'") {
+      val q                           = DynamoDBQuery.putItem("t", Item("id" -> "1"))
+      val filt: FilterExpression[Any] = ProjectionExpression.$("name") === "alice"
+      val result                      = q.filter(filt)
+      assert(result)(
+        isSubtype[DynamoDBQuery.Fail](
+          hasField(
+            "error",
+            _.error(),
+            isSubtype[DynamoDBError.QueryBuilderError.UnsupportedModifier](
+              hasField("message", _.message, containsString("'.where'"))
+            )
+          )
+        )
+      )
     },
     test("DescribeTableResponse toString includes tableArn") {
       val r = DynamoDBQuery.DescribeTableResponse("arn:aws:test", DynamoDBQuery.TableStatus.Active, 100L, 5L)


### PR DESCRIPTION
…ilently no-oping

Calling .where on a scan/query (or .filter on a put/update/delete, or .whereKey on anything but a query) previously fell through to `case _ => self`, silently discarding the condition/filter/key-condition expression and returning the original query unchanged — reported in zio/zio-dynamodb#748.

The query still builds successfully (same as before), but now the discarded branch becomes a DynamoDBQuery.Fail carrying a new DynamoDBError.QueryBuilderError.UnsupportedModifier, so the mistake surfaces as a typed error in the effect's error channel the moment the query executes, via the same runAny/Fail plumbing already used for every other construction-time validation error (ScanValidationError, TransactionValidationError, ...) — rather than a silent, wrong-but-successful result.