### PR TITLE
Finish zio-sbt-ci 0.7.2 upgrade: move off snapshot pin onto the real release

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,6 +14,7 @@ env: {}
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.run_id || github.ref }}
   cancel-in-progress: true
@@ -24,18 +25,11 @@ jobs:
     continue-on-error: false
     if: ${{ ((((github.event_name == 'workflow_dispatch') || (github.event.pull_request.user.login == 'dependabot[bot]')) || (github.event.pull_request.user.login == 'renovate[bot]')) || (github.event.pull_request.user.login == 'zio-scala-steward[bot]')) || (github.event.pull_request.user.login == 'scala-steward') }}
     steps:
-    - name: Generate Token
-      id: generate-token
-      uses: zio/generate-github-app-token@v1.0.0
-      if: ${{ secrets.APP_ID != '' }}
-      with:
-        app_id: ${{ secrets.APP_ID }}
-        app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - name: Enable auto-merge for bot PR
       if: ${{ github.event_name == 'pull_request_target' }}
       run: gh pr merge --auto --squash ${{ github.event.number }}
       env:
-        GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
     - name: Backfill auto-merge for existing bot PRs
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -50,5 +44,5 @@ jobs:
           xargs -I{} gh pr merge --auto --squash {}
         done
       env:
-        GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,7 @@
-resolvers += Resolver.sonatypeCentralSnapshots
-
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"    % "2.6.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"         % "0.4.8")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"   % "0.13.1")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"   % "2.4.3")
 addSbtPlugin("com.github.sbt"     % "sbt-ci-release"  % "1.12.1")
-addSbtPlugin("dev.zio"            % "zio-sbt-website" % "0.7.2+2-33329252-SNAPSHOT")
-addSbtPlugin("dev.zio"            % "zio-sbt-ci"      % "0.7.2+2-33329252-SNAPSHOT")
+addSbtPlugin("dev.zio"            % "zio-sbt-website" % "0.7.2")
+addSbtPlugin("dev.zio"            % "zio-sbt-ci"      % "0.7.2")


### PR DESCRIPTION
## Summary

Supersedes #939. Completes what Scala Steward's #939 was trying to do
(bump `zio-sbt-ci` / `zio-sbt-website` from 0.6.3 to the real, released
0.7.2), recreated on top of current `series/2.x` because #939 is stuck.

- `project/plugins.sbt`: `zio-sbt-website` / `zio-sbt-ci` moved from the
  temporary snapshot `0.7.2+2-33329252-SNAPSHOT` (pinned in #940) to the
  plain, released `0.7.2` (confirmed on Sonatype Central / Maven Central,
  tag `v0.7.2`, published 2026-08-25).
- Removed the `resolvers += Resolver.sonatypeCentralSnapshots` line added
  in #940 — it existed solely to resolve that snapshot; the real release
  resolves cleanly from Maven Central without it (verified locally via
  `sbt "reload plugins" update`, artifact fetched from
  `repo1.maven.org`, no snapshot resolver present).
- `.github/workflows/auto-merge.yml` regenerated via
  `sbt ciGenerateGithubWorkflow` against the real 0.7.2 plugin.
  `ci.yml` and `auto-approve.yml` came out byte-identical, so they're
  not touched by this PR.

## Why this exists / why not just rebase #939

#939 was opened by the Scala Steward bot from its own fork
(`scala-steward/zio-dynamodb`). It's currently `mergeable: CONFLICTING`
against `series/2.x`, because #940 (a manual verification bump) landed
on `series/2.x` first and pinned the snapshot version + regenerated
workflows to match. I don't have push access to Steward's fork, so I
can't rebase #939 myself, and Scala Steward's hosted rebase service
hasn't picked it up after ~2 days (longer than its usual daily
cadence). This PR recreates #939's intent directly on current
`series/2.x` HEAD instead of waiting further.

Once this merges, a maintainer can likely close #939 as superseded.

## ⚠️ Important regression to be aware of before merging

The regenerated `auto-merge.yml` is **not** equivalent to what's
currently on `series/2.x` (from #940's snapshot build) — it's a step
backward on one specific bug fix, not just a cosmetic diff:

- zio-sbt's [#762](https://github.com/zio/zio-sbt/pull/762) ("Mint a
  GitHub App token for auto-merge on workflow-touching PRs", fixing
  zio-sbt#744, originally discovered via our #926) merged into
  `zio-sbt` `main` at commit `3332925` on 2026-08-26T19:08:02Z.
- The `v0.7.2` tag was cut at commit `ab615fb` on
  2026-08-25T05:57:51Z/published 06:44:32Z — **before** #762 merged.
- So the real, released 0.7.2 does **not** contain the App-token fix.
  Regenerating against it drops the "Generate Token" step and reverts
  `GH_TOKEN` back to plain `secrets.GITHUB_TOKEN` in both the
  "Enable auto-merge for bot PR" and "Backfill auto-merge for existing
  bot PRs" steps, plus removes the `actions: write` permission that
  the snapshot generator had added.
- In other words: merging this PR as-is reintroduces the exact bug
  (`GITHUB_TOKEN` can't get the `workflows` scope needed for
  `enablePullRequestAutoMerge` on PRs touching
  `.github/workflows/**`) that #940's snapshot bump was manually
  verifying a fix for.

**Recommendation**: hold off merging this until `zio-sbt` cuts a
release that includes #762 (e.g. 0.7.3), then bump straight to that
version instead of 0.7.2 — or, if landing 0.7.2 now is preferred for
other reasons, manually re-apply the "Generate Token" step to
`auto-merge.yml` on top of this PR before merging. Flagging this here
rather than merging blind.

## Test plan

- [x] `sbt "reload plugins" update` — 0.7.2 resolves cleanly from
      Maven Central with no snapshot resolver present.
- [x] `sbt ciGenerateGithubWorkflow` — diffed output against what's on
      `series/2.x`; only `auto-merge.yml` differs (see above), `ci.yml`
      and `auto-approve.yml` are identical.
- [ ] CI (`ci` required status check) to run on this PR.
- [ ] Maintainer review/decision on the auto-merge.yml regression noted
      above before merging.

Refs #939, #940.