### PR TITLE
Add BigRecord (~26-field, nested, sum-typed) get/put benchmarks

### DIFF
--- a/benchmarks/src/main/scala/zio/dynamodb/CeEffectStackBench.scala
+++ b/benchmarks/src/main/scala/zio/dynamodb/CeEffectStackBench.scala
@@ -28,6 +28,7 @@ import zio.dynamodb.DynamoDBError.ItemError
 import zio.dynamodb.blocks.ddbexpr.{ DdbExprApi, DdbKeyExpr }
 import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
 import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
+import zio.dynamodb.blocks.schema.{ DynamoDBCodec, DynamoDBCodecDeriver }
 
 import org.openjdk.jmh.annotations.{ Benchmark, Setup, Warmup }
 import java.lang.reflect.{ InvocationHandler, Method, Proxy }
@@ -55,9 +56,13 @@ import scala.collection.JavaConverters._
 @Warmup(iterations = 10, time = 1, timeUnit = java.util.concurrent.TimeUnit.SECONDS)
 class CeEffectStackBench extends BaseBenchmark {
 
-  private val TABLE    = "users"
-  private val personId = 12345678901L
-  private val person   = Person(personId, "John", 30, Some("123 Main St"))
+  private val TABLE     = "users"
+  private val BIG_TABLE = "products"
+  private val personId  = 12345678901L
+  private val person    = Person(personId, "John", 30, Some("123 Main St"))
+
+  private val bigRecord = BigRecord.sample
+  private val bigId     = bigRecord.id
 
   // ── Canned AWS responses ────────────────────────────────────────────────
 
@@ -74,13 +79,30 @@ class CeEffectStackBench extends BaseBenchmark {
   private val cannedPutResponse: PutItemResponse =
     PutItemResponse.builder().build()
 
+  // BigRecord canned GET responses — each library reads back a payload in its own
+  // native wire shape, produced by that library's own encoder.
+  private val zioBlocksBigCodec: DynamoDBCodec[BigRecord] =
+    BigRecord.blocksSchema.deriving(DynamoDBCodecDeriver).derive
+
+  private val bigItemBlocks: Item =
+    FromAttributeValue.attrMapFromAttributeValue
+      .fromAttributeValue(zioBlocksBigCodec.encoder(bigRecord))
+      .fold(e => sys.error(s"blocks BigRecord encode failed: $e"), identity)
+
+  private val cannedGetResponseBigBlocks: GetItemResponse =
+    GetItemResponse.builder().item(AwsCodecs.toAwsItem(bigItemBlocks)).build()
+
+  private val cannedGetResponseBigScanamo: GetItemResponse =
+    GetItemResponse.builder().item(ScanamoCodec.bigRecord.write(bigRecord).toAttributeValue.m()).build()
+
   // ── blocks-dynamodb CE interpreter ─────────────────────────────────────
 
   // Stub AwsDynamoDB[IO]: returns canned responses as already-completed IO.pure
   // values — zero async dispatch, isolates effect-stack overhead.
   private val stubDynamo: AwsDynamoDB[IO] = new AwsDynamoDB[IO] {
     private def unsupported                                                                = IO.raiseError[Nothing](new UnsupportedOperationException("stub"))
-    def getItem(req: GetItemRequest): IO[GetItemResponse]                                  = IO.pure(cannedGetResponse)
+    def getItem(req: GetItemRequest): IO[GetItemResponse]                                  =
+      IO.pure(if (req.tableName == BIG_TABLE) cannedGetResponseBigBlocks else cannedGetResponse)
     def putItem(req: PutItemRequest): IO[PutItemResponse]                                  = IO.pure(cannedPutResponse)
     def updateItem(req: UpdateItemRequest): IO[UpdateItemResponse]                         = unsupported
     def deleteItem(req: DeleteItemRequest): IO[DeleteItemResponse]                         = unsupported
@@ -103,6 +125,10 @@ class CeEffectStackBench extends BaseBenchmark {
     val name = $(_.name)
   }
 
+  private object BigRecordOps extends CompanionOptics[BigRecord] {
+    val id = $(_.id)
+  }
+
   // ── Scanamo sync wrapped in IO.delay ────────────────────────────────────
 
   // Stub DynamoDbClient (sync) via Java Proxy — only getItem / putItem need to
@@ -110,7 +136,9 @@ class CeEffectStackBench extends BaseBenchmark {
   private val stubSyncHandler: InvocationHandler = new InvocationHandler {
     def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef =
       method.getName match {
-        case "getItem"     => cannedGetResponse
+        case "getItem"     =>
+          if (args(0).asInstanceOf[GetItemRequest].tableName == BIG_TABLE) cannedGetResponseBigScanamo
+          else cannedGetResponse
         case "putItem"     => cannedPutResponse
         case "serviceName" => "dynamodb"
         case "close"       => null
@@ -128,16 +156,21 @@ class CeEffectStackBench extends BaseBenchmark {
 
   private val scanamo = Scanamo(stubSyncClient)
 
-  private val scanamoTable = Table[Person](TABLE)(ScanamoCodec.person)
+  private val scanamoTable    = Table[Person](TABLE)(ScanamoCodec.person)
+  private val bigScanamoTable = Table[BigRecord](BIG_TABLE)(ScanamoCodec.bigRecord)
 
   // ── Step 2: pre-built queries (set in @Setup) ───────────────────────────
 
-  private var prebuiltGetQuery: DynamoDBQuery[Person, Either[ItemError, Person]] = _
-  private var prebuiltPutQuery: DynamoDBQuery[Person, Option[Person]]            = _
+  private var prebuiltGetQuery: DynamoDBQuery[Person, Either[ItemError, Person]]          = _
+  private var prebuiltPutQuery: DynamoDBQuery[Person, Option[Person]]                     = _
+  private var prebuiltBigGetQuery: DynamoDBQuery[BigRecord, Either[ItemError, BigRecord]] = _
+  private var prebuiltBigPutQuery: DynamoDBQuery[BigRecord, Option[BigRecord]]            = _
 
   @Setup def setup(): Unit = {
     prebuiltGetQuery = DdbExprApi.get[Person](TABLE)(PersonOps.id.partitionKey === personId)
     prebuiltPutQuery = DdbExprApi.put(TABLE, person)
+    prebuiltBigGetQuery = DdbExprApi.get[BigRecord](BIG_TABLE)(BigRecordOps.id.partitionKey === bigId)
+    prebuiltBigPutQuery = DdbExprApi.put(BIG_TABLE, bigRecord)
   }
 
   // ── Benchmarks ──────────────────────────────────────────────────────────
@@ -181,5 +214,35 @@ class CeEffectStackBench extends BaseBenchmark {
   /** Construction only: DdbExprApi.put, never interpreted/run. Isolates query-building cost. */
   @Benchmark def blocksPutConstructOnly: DynamoDBQuery[Person, Option[Person]] =
     DdbExprApi.put(TABLE, person)
+
+  // ── BigRecord (~26 fields, nested + sum types) — realistic-payload variants ─
+
+  @Benchmark def blocksGetBig: Either[ItemError, BigRecord] =
+    interpreter
+      .run(DdbExprApi.get[BigRecord](BIG_TABLE)(BigRecordOps.id.partitionKey === bigId))
+      .unsafeRunSync()
+
+  @Benchmark def blocksPutBig: Option[BigRecord] =
+    interpreter
+      .run(DdbExprApi.put(BIG_TABLE, bigRecord))
+      .unsafeRunSync()
+
+  @Benchmark def scanamoGetBig: Option[Either[DynamoReadError, BigRecord]] =
+    IO.delay(scanamo.exec(bigScanamoTable.get("id" === bigId))).unsafeRunSync()
+
+  @Benchmark def scanamoPutBig: Unit =
+    IO.delay(scanamo.exec(bigScanamoTable.put(bigRecord))).unsafeRunSync()
+
+  @Benchmark def blocksGetBigPrebuilt: Either[ItemError, BigRecord] =
+    interpreter.run(prebuiltBigGetQuery).unsafeRunSync()
+
+  @Benchmark def blocksPutBigPrebuilt: Option[BigRecord] =
+    interpreter.run(prebuiltBigPutQuery).unsafeRunSync()
+
+  @Benchmark def blocksGetBigConstructOnly: DynamoDBQuery[BigRecord, Either[ItemError, BigRecord]] =
+    DdbExprApi.get[BigRecord](BIG_TABLE)(BigRecordOps.id.partitionKey === bigId)
+
+  @Benchmark def blocksPutBigConstructOnly: DynamoDBQuery[BigRecord, Option[BigRecord]] =
+    DdbExprApi.put(BIG_TABLE, bigRecord)
 
 }

--- a/benchmarks/src/main/scala/zio/dynamodb/DynamoDBCodecBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/dynamodb/DynamoDBCodecBenchmarks.scala
@@ -190,4 +190,110 @@ object BenchmarkDomain {
   val zioSchemaDecoder: Decoder[Person] = Codec.decoder[Person](zioSchema)
 
   val zioBlocksCodec: DynamoDBCodec[Person] = Schema.derived.deriving(DynamoDBCodecDeriver).derive
+
+  // ── Large, nested, sum-typed record ──────────────────────────────────────
+  // ~26 top-level fields, 5 distinct nested case-class types, 3 sum types
+  // (a pure enumeration, a mixed data/object union, and a data-carrying union),
+  // Options, List, Vector and Map. Used by CeEffectStackBench to compare get/put
+  // on a realistic payload rather than the flat 4-field Person.
+
+  sealed trait Priority
+  object Priority {
+    case object Low      extends Priority
+    case object Medium   extends Priority
+    case object High     extends Priority
+    case object Critical extends Priority
+    implicit val schema: Schema[Priority] = Schema.derived
+  }
+
+  sealed trait Fulfilment
+  object Fulfilment {
+    final case class Warehouse(code: String)                 extends Fulfilment
+    final case class DropShip(vendor: String, leadDays: Int) extends Fulfilment
+    case object Pickup                                       extends Fulfilment
+    implicit val schema: Schema[Fulfilment] = Schema.derived
+  }
+
+  sealed trait Contact
+  object Contact {
+    final case class Email(address: String)                  extends Contact
+    final case class Phone(number: String, ext: Option[Int]) extends Contact
+    implicit val schema: Schema[Contact] = Schema.derived
+  }
+
+  final case class Address(street: String, city: String, state: String, zip: String, country: String)
+  object Address { implicit val schema: Schema[Address] = Schema.derived }
+
+  final case class GeoPoint(lat: Double, lng: Double)
+  object GeoPoint { implicit val schema: Schema[GeoPoint] = Schema.derived }
+
+  final case class AuditInfo(createdBy: String, createdAt: Long, updatedBy: String, updatedAt: Long, version: Int)
+  object AuditInfo { implicit val schema: Schema[AuditInfo] = Schema.derived }
+
+  final case class Money(currency: String, amountMinor: Long)
+  object Money { implicit val schema: Schema[Money] = Schema.derived }
+
+  final case class Dimensions(widthMm: Int, heightMm: Int, depthMm: Int, weightG: Long)
+  object Dimensions { implicit val schema: Schema[Dimensions] = Schema.derived }
+
+  final case class BigRecord(
+    id: Long,
+    sku: String,
+    name: String,
+    description: String,
+    category: String,
+    subCategory: String,
+    brand: String,
+    priority: Priority,
+    fulfilment: Fulfilment,
+    primaryContact: Contact,
+    secondaryContact: Option[Contact],
+    billingAddress: Address,
+    shippingAddress: Option[Address],
+    location: GeoPoint,
+    audit: AuditInfo,
+    price: Money,
+    cost: Money,
+    dimensions: Dimensions,
+    tags: List[String],
+    ratings: Vector[Int],
+    attributes: Map[String, String],
+    quantityOnHand: Int,
+    reorderPoint: Int,
+    discontinued: Boolean,
+    averageRating: Double,
+    notes: Option[String]
+  )
+  object BigRecord {
+    implicit val blocksSchema: Schema[BigRecord] = Schema.derived
+
+    val sample: BigRecord = BigRecord(
+      id = 999000111222L,
+      sku = "SKU-ABC-12345",
+      name = "Widget Assembly, Deluxe",
+      description = "A deluxe widget assembly with reinforced housing and extended warranty.",
+      category = "Hardware",
+      subCategory = "Assemblies",
+      brand = "Acme",
+      priority = Priority.High,
+      fulfilment = Fulfilment.DropShip("vendor-42", leadDays = 5),
+      primaryContact = Contact.Email("sales@example.com"),
+      secondaryContact = Some(Contact.Phone("+1-555-0100", ext = Some(220))),
+      billingAddress = Address("1 Market St", "San Francisco", "CA", "94105", "US"),
+      shippingAddress = Some(Address("500 Terry A Francois Blvd", "San Francisco", "CA", "94158", "US")),
+      location = GeoPoint(37.7749, -122.4194),
+      audit = AuditInfo("import-job", 1_724_000_000_000L, "ops-user", 1_724_900_000_000L, version = 7),
+      price = Money("USD", amountMinor = 129_99L),
+      cost = Money("USD", amountMinor = 74_50L),
+      dimensions = Dimensions(widthMm = 320, heightMm = 180, depthMm = 95, weightG = 2_400L),
+      tags = List("featured", "clearance", "bulk-eligible"),
+      ratings = Vector(5, 4, 5, 3, 5, 4),
+      attributes = Map("colour" -> "graphite", "material" -> "aluminium", "finish" -> "matte"),
+      quantityOnHand = 1_284,
+      reorderPoint = 200,
+      discontinued = false,
+      averageRating = 4.33,
+      notes = Some("Palletised; 24 units per pallet.")
+    )
+  }
 }

--- a/benchmarks/src/main/scala/zio/dynamodb/ScanamoCodec.scala
+++ b/benchmarks/src/main/scala/zio/dynamodb/ScanamoCodec.scala
@@ -25,4 +25,16 @@ object ScanamoCodec {
   implicit val trafficLight: DynamoFormat[TrafficLight]   = deriveDynamoFormat
   implicit val tuple: DynamoFormat[(Int, Long, String)]   = deriveDynamoFormat
   implicit val person: DynamoFormat[Person]               = deriveDynamoFormat
+
+  // BigRecord and its nested/sum members — leaves first so the implicit vals are
+  // initialised before deriveDynamoFormat[BigRecord] references them.
+  implicit val priority: DynamoFormat[Priority]     = deriveDynamoFormat
+  implicit val fulfilment: DynamoFormat[Fulfilment] = deriveDynamoFormat
+  implicit val contact: DynamoFormat[Contact]       = deriveDynamoFormat
+  implicit val address: DynamoFormat[Address]       = deriveDynamoFormat
+  implicit val geoPoint: DynamoFormat[GeoPoint]     = deriveDynamoFormat
+  implicit val auditInfo: DynamoFormat[AuditInfo]   = deriveDynamoFormat
+  implicit val money: DynamoFormat[Money]           = deriveDynamoFormat
+  implicit val dimensions: DynamoFormat[Dimensions] = deriveDynamoFormat
+  implicit val bigRecord: DynamoFormat[BigRecord]   = deriveDynamoFormat
 }


### PR DESCRIPTION
CeEffectStackBench only exercised a flat 4-field Person, where query construction and effect-stack overhead dominate and the codec advantage is hidden. Add a realistic payload to compare against Scanamo
