### PR TITLE
series/3.x Fix combined .filter/.where conditions bypassing Table config

### DIFF
--- a/it/src/test/scala/zio/dynamodb/DdbExprApiSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/DdbExprApiSpec.scala
@@ -24,7 +24,7 @@ import zio.blocks.schema.{ CompanionOptics, Lens, Modifier, NameMapper, Schema }
 import zio.dynamodb.blocks.ddbexpr.{ DdbExprApi, DdbKeyExpr }
 import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
 import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
-import zio.dynamodb.blocks.ddbexpr.DdbExpr.{ DdbExprBoolSyntax, OpticDdbExprOps, OpticUpdateOps }
+import zio.dynamodb.blocks.ddbexpr.DdbExpr.{ DdbExprBoolSyntax, OpticDdbExprOps, OpticUpdateOps, SchemaExprBoolBridge }
 import zio.test._
 import zio.test.Assertion._
 import zio.test.TestAspect
@@ -613,13 +613,32 @@ object DdbExprApiSpec extends DynamoDBLocalSpec {
             page.items == Chunk(Right(Article("a2", "Second", ArticleStatus.Published)))
           )
         }
+      },
+      test("scan.filter on a combined (&&) config-mapped condition") {
+        // Regression test for a bug where `SchemaExpr && SchemaExpr` used to silently resolve
+        // to a no-config ConditionExpression (via DdbExprApiSyntax's own
+        // schemaExprToConditionExpression, competing with SchemaExprBoolBridge to adapt the
+        // receiver) instead of staying a SchemaExpr/DdbExpr, baking in unconfigured
+        // names/literals before .filter ever saw the expression. Fixed by moving that
+        // conversion (and its siblings) out of DdbExprApiSyntax into the separately-imported
+        // LowLevelDdbExprSyntax - DdbExprApi._ alone can no longer reach that path at all, with
+        // or without SchemaExprBoolBridge also imported - see DdbExprFilterConfigSpec in
+        // schema-ddbexpr for a fast (non-IT) proof.
+        withSingleIdKeyTable { (tableName, interpreter) =>
+          val table = configuredArticleTable(tableName)
+          for {
+            _    <- interpreter.run(DdbExprApi.put(table, Article("a1", "First", ArticleStatus.Draft)))
+            _    <- interpreter.run(DdbExprApi.put(table, Article("a2", "Second", ArticleStatus.Published)))
+            page <- interpreter.run(
+                      DdbExprApi
+                        .scan[Article](table, 10)
+                        .filter(Article.displayName === "Second" && Article.status === ArticleStatus.Published)
+                    )
+          } yield assertTrue(
+            page.items == Chunk(Right(Article("a2", "Second", ArticleStatus.Published)))
+          )
+        }
       }
-      // A combined (&&) scan.filter test was here (displayName === X && status === Y). It
-      // fails against real DynamoDB regardless of Table config - reproduces identically on
-      // a completely unconfigured table, and the constructed FilterExpression was verified
-      // correct (in isolation, without Docker) before ruling that out. Pre-existing gap,
-      // unrelated to Table config threading: no existing test exercised a combined-condition
-      // scan filter before. Tracked separately rather than fixed here.
     )
 
   def spec =

--- a/it/src/test/scala/zio/dynamodb/DdbExprApiSpec.scala
+++ b/it/src/test/scala/zio/dynamodb/DdbExprApiSpec.scala
@@ -615,15 +615,10 @@ object DdbExprApiSpec extends DynamoDBLocalSpec {
         }
       },
       test("scan.filter on a combined (&&) config-mapped condition") {
-        // Regression test for a bug where `SchemaExpr && SchemaExpr` used to silently resolve
-        // to a no-config ConditionExpression (via DdbExprApiSyntax's own
-        // schemaExprToConditionExpression, competing with SchemaExprBoolBridge to adapt the
-        // receiver) instead of staying a SchemaExpr/DdbExpr, baking in unconfigured
-        // names/literals before .filter ever saw the expression. Fixed by moving that
-        // conversion (and its siblings) out of DdbExprApiSyntax into the separately-imported
-        // LowLevelDdbExprSyntax - DdbExprApi._ alone can no longer reach that path at all, with
-        // or without SchemaExprBoolBridge also imported - see DdbExprFilterConfigSpec in
-        // schema-ddbexpr for a fast (non-IT) proof.
+        // A combined (&&) filter against a configured table: the two conditions combine
+        // via SchemaExpr's own && and `.filter` resolves both field names and the enum
+        // literal against the table config. DdbExprFilterConfigSpec (schema-ddbexpr) covers
+        // the import-shape variations without Docker.
         withSingleIdKeyTable { (tableName, interpreter) =>
           val table = configuredArticleTable(tableName)
           for {

--- a/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/DdbExprApi.scala
+++ b/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/DdbExprApi.scala
@@ -171,13 +171,10 @@ final class WriteBuilder[From] private[ddbexpr] (
  *      .filter(Task.name.beginsWith("A") && Task.score.between(1, 100))
  *  }}}
  *
- *  `.whereKey` / `.filter` / `.where` on the builders above accept `DdbKeyExpr` / `DdbExpr` /
- *  `SchemaExpr` directly - no implicit conversion involved, and each threads the table's own
- *  configuration. A genuinely bare [[DynamoDBQuery]] (no [[Table]] behind it) needs its own,
- *  separately-imported escape hatch instead - see [[LowLevelDdbExprSyntax]] / `DdbExprLowLevel`
- *  for why that is deliberately not bundled here. Interpretation failures on the builders above
- *  are deferred to query execution via the `Failure` nodes in [[KeyConditionExpr]] and
- *  [[ConditionExpression]].
+ *  `.whereKey` / `.filter` / `.where` on the builders take `DdbKeyExpr` / `DdbExpr` /
+ *  `SchemaExpr` through overloads on the builder, each interpreting the argument against the
+ *  calling table's configuration. Interpretation failures surface at query execution via the
+ *  `Failure` nodes in [[KeyConditionExpr]] and [[ConditionExpression]].
  */
 trait DdbExprApiSyntax {
 
@@ -282,55 +279,6 @@ trait DdbExprApiSyntax {
   implicit def writeBuilderToQuery[From](b: WriteBuilder[From]): DynamoDBQuery[From, Option[From]] = b.toQuery
 
 }
-
-/**
- * Implicit conversions enabling `.whereKey(DdbKeyExpr)` / `.filter(DdbExpr)` /
- * `.filter(SchemaExpr)` / `.where(...)` on a genuinely bare [[DynamoDBQuery]] - one built
- * directly via `core`'s own constructors (`DynamoDBQuery.scan`, `.query`, ...), not through
- * a [[Table]] / [[ScanBuilder]] / [[QueryBuilder]] / [[WriteBuilder]]. None of these carry
- * table configuration - the builders `DdbExprApi.scan` / `.query` / `.put` / `.update` /
- * `.deleteFrom` return do, via each builder's own `SchemaExpr` / `DdbExpr` /
- * `ConditionExpression` overloads, which do not need (and are unaffected by) this trait.
- *
- * Deliberately NOT mixed into [[DdbExprApiSyntax]] / `dsl` - unlike those, this trait puts a
- * plain implicit conversion of `SchemaExpr` into scope (`schemaExprToConditionExpression`),
- * not merely an extension method. A plain conversion is eligible wherever Scala looks for a
- * way to adapt a `SchemaExpr` receiver to expose a member it doesn't have - including `&&` /
- * `||`, which ZB's own `SchemaExpr` already provides via `SchemaExpr.BooleanOps`. Mixing this
- * trait into the same scope as `DdbExprApiSyntax`/`dsl` would make `SchemaExpr && SchemaExpr`
- * a second, silently-different way to combine two conditions - converting straight to a
- * no-config `ConditionExpression` and losing whatever `Table` configuration the fields
- * involved would otherwise resolve through - instead of just extending `SchemaExpr`'s own
- * `&&`. Keeping it in its own, separately-imported trait means a caller only takes on that
- * risk by explicitly asking for the low-level escape hatch, not merely by importing
- * `DdbExprApi._` / `dsl._` for the (unrelated) `Table`-based builders.
- */
-trait LowLevelDdbExprSyntax {
-
-  // Enables .whereKey(ddbKeyExpr) on any low-level DynamoDBQuery.
-  // Interpretation failures are deferred to execution via KeyConditionExpr.Failure.
-  implicit def ddbKeyExprToKeyConditionExpr[S](expr: DdbKeyExpr[S]): KeyConditionExpr[S] =
-    DdbKeyExprInterpreter.toKeyConditionExpr(expr).fold(KeyConditionExpr.Failure(_), identity)
-
-  // Enables .filter(ddbExpr) and .where(ddbExpr) on any low-level DynamoDBQuery.
-  // FilterExpression[-From] is a type alias for ConditionExpression[-From].
-  // Interpretation failures are deferred to execution via ConditionExpression.Failure.
-  implicit def ddbExprToConditionExpression[S](expr: DdbExpr[S, Boolean]): ConditionExpression[S] =
-    DdbExprInterpreter.toConditionExpression(expr).fold(ConditionExpression.Failure(_), identity)
-
-  // Enables .filter(Task.score > 0) or .filter(Task.priority === Priority.High) where
-  // the argument is a ZB SchemaExpr. Goes through the Builtin path; the interpreter
-  // derives a DynamoDBCodec from the embedded Schema[_] in each Literal node.
-  implicit def schemaExprToConditionExpression[S](se: SchemaExpr[S, Boolean]): ConditionExpression[S] =
-    ddbExprToConditionExpression(DdbExpr.Builtin(se))
-}
-
-/**
- * `import DdbExprLowLevel._` - the escape hatch for a genuinely bare [[DynamoDBQuery]] with no
- * [[Table]] behind it. See [[LowLevelDdbExprSyntax]] for why this needs its own import
- * separate from [[DdbExprApi]] / `dsl`.
- */
-object DdbExprLowLevel extends LowLevelDdbExprSyntax
 
 /**
  * The [[DdbExprApiSyntax]] singleton - `import DdbExprApi._` for explicit-object-style

--- a/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/DdbExprApi.scala
+++ b/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/DdbExprApi.scala
@@ -171,13 +171,13 @@ final class WriteBuilder[From] private[ddbexpr] (
  *      .filter(Task.name.beginsWith("A") && Task.score.between(1, 100))
  *  }}}
  *
- *  Importing [[DdbExprApi]]`._ ` brings the implicit conversions
- *  [[DdbExprApiSyntax.ddbKeyExprToKeyConditionExpr]], [[DdbExprApiSyntax.ddbExprToConditionExpression]], and
- *  [[DdbExprApiSyntax.schemaExprToConditionExpression]] into scope, enabling `.whereKey(DdbKeyExpr)`,
- *  `.filter(DdbExpr)`, and `.filter(SchemaExpr)` on any low-level [[DynamoDBQuery]] (these
- *  do not carry table configuration - the builders returned by `query` / `scan` do).
- *  Interpretation failures are deferred to query execution via the `Failure` nodes in
- *  [[KeyConditionExpr]] and [[ConditionExpression]].
+ *  `.whereKey` / `.filter` / `.where` on the builders above accept `DdbKeyExpr` / `DdbExpr` /
+ *  `SchemaExpr` directly - no implicit conversion involved, and each threads the table's own
+ *  configuration. A genuinely bare [[DynamoDBQuery]] (no [[Table]] behind it) needs its own,
+ *  separately-imported escape hatch instead - see [[LowLevelDdbExprSyntax]] / `DdbExprLowLevel`
+ *  for why that is deliberately not bundled here. Interpretation failures on the builders above
+ *  are deferred to query execution via the `Failure` nodes in [[KeyConditionExpr]] and
+ *  [[ConditionExpression]].
  */
 trait DdbExprApiSyntax {
 
@@ -281,7 +281,31 @@ trait DdbExprApiSyntax {
 
   implicit def writeBuilderToQuery[From](b: WriteBuilder[From]): DynamoDBQuery[From, Option[From]] = b.toQuery
 
-  // -- Implicit conversions (low-level path - no table configuration) ----------
+}
+
+/**
+ * Implicit conversions enabling `.whereKey(DdbKeyExpr)` / `.filter(DdbExpr)` /
+ * `.filter(SchemaExpr)` / `.where(...)` on a genuinely bare [[DynamoDBQuery]] - one built
+ * directly via `core`'s own constructors (`DynamoDBQuery.scan`, `.query`, ...), not through
+ * a [[Table]] / [[ScanBuilder]] / [[QueryBuilder]] / [[WriteBuilder]]. None of these carry
+ * table configuration - the builders `DdbExprApi.scan` / `.query` / `.put` / `.update` /
+ * `.deleteFrom` return do, via each builder's own `SchemaExpr` / `DdbExpr` /
+ * `ConditionExpression` overloads, which do not need (and are unaffected by) this trait.
+ *
+ * Deliberately NOT mixed into [[DdbExprApiSyntax]] / `dsl` - unlike those, this trait puts a
+ * plain implicit conversion of `SchemaExpr` into scope (`schemaExprToConditionExpression`),
+ * not merely an extension method. A plain conversion is eligible wherever Scala looks for a
+ * way to adapt a `SchemaExpr` receiver to expose a member it doesn't have - including `&&` /
+ * `||`, which ZB's own `SchemaExpr` already provides via `SchemaExpr.BooleanOps`. Mixing this
+ * trait into the same scope as `DdbExprApiSyntax`/`dsl` would make `SchemaExpr && SchemaExpr`
+ * a second, silently-different way to combine two conditions - converting straight to a
+ * no-config `ConditionExpression` and losing whatever `Table` configuration the fields
+ * involved would otherwise resolve through - instead of just extending `SchemaExpr`'s own
+ * `&&`. Keeping it in its own, separately-imported trait means a caller only takes on that
+ * risk by explicitly asking for the low-level escape hatch, not merely by importing
+ * `DdbExprApi._` / `dsl._` for the (unrelated) `Table`-based builders.
+ */
+trait LowLevelDdbExprSyntax {
 
   // Enables .whereKey(ddbKeyExpr) on any low-level DynamoDBQuery.
   // Interpretation failures are deferred to execution via KeyConditionExpr.Failure.
@@ -300,6 +324,13 @@ trait DdbExprApiSyntax {
   implicit def schemaExprToConditionExpression[S](se: SchemaExpr[S, Boolean]): ConditionExpression[S] =
     ddbExprToConditionExpression(DdbExpr.Builtin(se))
 }
+
+/**
+ * `import DdbExprLowLevel._` - the escape hatch for a genuinely bare [[DynamoDBQuery]] with no
+ * [[Table]] behind it. See [[LowLevelDdbExprSyntax]] for why this needs its own import
+ * separate from [[DdbExprApi]] / `dsl`.
+ */
+object DdbExprLowLevel extends LowLevelDdbExprSyntax
 
 /**
  * The [[DdbExprApiSyntax]] singleton - `import DdbExprApi._` for explicit-object-style

--- a/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/dsl.scala
+++ b/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/dsl.scala
@@ -41,12 +41,5 @@ package zio.dynamodb.blocks.ddbexpr
  *  This is purely a convenience for the common case — `DdbExprApi`, `DdbKeyExpr`, and
  *  `DdbExpr` remain independently importable exactly as before for callers who want only
  *  one piece (e.g. a test exercising `DdbKeyExpr` in isolation).
- *
- *  Deliberately excludes [[LowLevelDdbExprSyntax]] (`DdbExprLowLevel`) - the escape hatch for
- *  running a `DdbKeyExpr` / `DdbExpr` / `SchemaExpr` condition against a bare, `Table`-free
- *  [[DynamoDBQuery]]. That trait's `SchemaExpr => ConditionExpression` conversion competes
- *  with `SchemaExpr`'s own `&&` / `||`, so keeping it out of this facade means a plain
- *  `import dsl._` can never lose a `Table`'s configuration through that path; import
- *  `DdbExprLowLevel._` explicitly on top of `dsl._` if a bare query genuinely needs it.
  */
 object dsl extends DdbExprApiSyntax with DdbKeyExprSyntax with DdbExprSyntax

--- a/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/dsl.scala
+++ b/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/dsl.scala
@@ -41,5 +41,12 @@ package zio.dynamodb.blocks.ddbexpr
  *  This is purely a convenience for the common case — `DdbExprApi`, `DdbKeyExpr`, and
  *  `DdbExpr` remain independently importable exactly as before for callers who want only
  *  one piece (e.g. a test exercising `DdbKeyExpr` in isolation).
+ *
+ *  Deliberately excludes [[LowLevelDdbExprSyntax]] (`DdbExprLowLevel`) - the escape hatch for
+ *  running a `DdbKeyExpr` / `DdbExpr` / `SchemaExpr` condition against a bare, `Table`-free
+ *  [[DynamoDBQuery]]. That trait's `SchemaExpr => ConditionExpression` conversion competes
+ *  with `SchemaExpr`'s own `&&` / `||`, so keeping it out of this facade means a plain
+ *  `import dsl._` can never lose a `Table`'s configuration through that path; import
+ *  `DdbExprLowLevel._` explicitly on top of `dsl._` if a bare query genuinely needs it.
  */
 object dsl extends DdbExprApiSyntax with DdbKeyExprSyntax with DdbExprSyntax

--- a/schema-ddbexpr/src/test/scala/zio/dynamodb/DdbExprApiSpec.scala
+++ b/schema-ddbexpr/src/test/scala/zio/dynamodb/DdbExprApiSpec.scala
@@ -18,9 +18,8 @@ package zio.dynamodb
 
 import zio.blocks.schema.{ CompanionOptics, Lens, Schema }
 import zio.dynamodb.DynamoDBError.ItemError
-import zio.dynamodb.blocks.ddbexpr.{ DdbExpr, DdbExprApi, DdbExprLowLevel, DdbKeyExpr }
+import zio.dynamodb.blocks.ddbexpr.{ DdbExpr, DdbExprApi, DdbKeyExpr }
 import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
-import zio.dynamodb.blocks.ddbexpr.DdbExprLowLevel._
 // derivedCodec from DdbKeyExpr._; bring DdbExpr extension methods separately
 // to avoid the two-derivedCodec ambiguity with DdbExpr.derivedCodec.
 import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
@@ -103,20 +102,6 @@ object DdbExprApiSpec extends ZIOSpecDefault {
       }
       // Range expressions (sk > / between / beginsWith) on get are now a compile-time error:
       // DdbExprApi.get takes DdbKeyExpr.PrimaryKey, which Extended does not satisfy.
-    ),
-    suite("implicit conversions")(
-      test("DdbKeyExpr converts to PartitionKeyEquals (not Failure)") {
-        val kce = ddbKeyExprToKeyConditionExpr[Task](Task.id.partitionKey === "alice")
-        assert(kce)(isSubtype[KeyConditionExpr.PartitionKeyEquals[Task]](anything))
-      },
-      test("DdbKeyExpr composite converts to CompositePrimaryKeyExpr") {
-        val kce = ddbKeyExprToKeyConditionExpr[Task](Task.id.partitionKey === "alice" && Task.score.sortKey === 42)
-        assert(kce)(isSubtype[KeyConditionExpr.CompositePrimaryKeyExpr[Task]](anything))
-      },
-      test("DdbExpr converts to non-Failure ConditionExpression") {
-        val ce = ddbExprToConditionExpression[Task](Task.id === "alice")
-        assert(ce)(not(isSubtype[ConditionExpression.Failure[Task]](anything)))
-      }
     ),
     suite("query / scan chaining")(
       test("query builds successfully with .whereKey and .filter (===)") {

--- a/schema-ddbexpr/src/test/scala/zio/dynamodb/DdbExprApiSpec.scala
+++ b/schema-ddbexpr/src/test/scala/zio/dynamodb/DdbExprApiSpec.scala
@@ -18,8 +18,9 @@ package zio.dynamodb
 
 import zio.blocks.schema.{ CompanionOptics, Lens, Schema }
 import zio.dynamodb.DynamoDBError.ItemError
-import zio.dynamodb.blocks.ddbexpr.{ DdbExpr, DdbExprApi, DdbKeyExpr }
+import zio.dynamodb.blocks.ddbexpr.{ DdbExpr, DdbExprApi, DdbExprLowLevel, DdbKeyExpr }
 import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
+import zio.dynamodb.blocks.ddbexpr.DdbExprLowLevel._
 // derivedCodec from DdbKeyExpr._; bring DdbExpr extension methods separately
 // to avoid the two-derivedCodec ambiguity with DdbExpr.derivedCodec.
 import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._

--- a/schema-ddbexpr/src/test/scala/zio/dynamodb/DdbExprFilterConfigSpec.scala
+++ b/schema-ddbexpr/src/test/scala/zio/dynamodb/DdbExprFilterConfigSpec.scala
@@ -16,7 +16,7 @@
 
 package zio.dynamodb
 
-import zio.blocks.schema.{ CompanionOptics, Lens, NameMapper, Schema }
+import zio.blocks.schema.{ CompanionOptics, Lens, NameMapper, Schema, SchemaExpr }
 import zio.dynamodb.blocks.DynamoDBCodecDeriverConfig
 import zio.dynamodb.blocks.ddbexpr.{ DdbExpr, DdbExprInterpreter }
 import zio.dynamodb.blocks.ddbexpr.dsl._
@@ -98,6 +98,92 @@ object DdbExprFilterConfigSpec extends ZIOSpecDefault {
     Order.schema.deriving(cfg.toDeriver).derive.recordFieldNameMap(scalaField)
 
   def spec = suite("DdbExprFilterConfigSpec")(
+    // Root cause of the `&&`/`||` config-loss bug that motivated this suite: `SchemaExpr` gets
+    // `&&`/`||` from ZB's own `SchemaExpr.BooleanOps` (native to SchemaExpr's companion,
+    // always in scope, no import needed) returning `SchemaExpr` again - safe, since the
+    // combined expression stays a `SchemaExpr` all the way to `.filter`/`.where`, which
+    // resolves it against the table's config. The bug was that `DdbExprApi._` used to
+    // ALSO put `schemaExprToConditionExpression` (a plain implicit *conversion*, not an
+    // extension method) into scope - competing to adapt the same `SchemaExpr` receiver, and
+    // winning when `DdbExpr.SchemaExprBoolBridge` wasn't separately imported, converting
+    // straight to a no-config `ConditionExpression` before `.filter` ever saw it. Fixed by
+    // moving that conversion (and its siblings) out of `DdbExprApiSyntax` into the
+    // separately-imported `LowLevelDdbExprSyntax` (`DdbExprLowLevel`) - so `DdbExprApi._` /
+    // `dsl._` alone can no longer reach that path at all, whether or not
+    // `SchemaExprBoolBridge` is also imported.
+    test("import DdbExprApi._ alone: 3-term && chain no longer reaches ConditionExpression, honours config") {
+      import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
+      import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
+      import zio.dynamodb.blocks.ddbexpr.DdbExpr.{ DdbExprBoolSyntax, OpticDdbExprOps, OpticUpdateOps }
+      val cfg      = DynamoDBCodecDeriverConfig[Order]().withFieldNameMapper(NameMapper.SnakeCase)
+      val combined = Order.customerId === "c1" && Order.orderRef === "r1" && Order.status === Status.Shipped
+      // No competing schemaExprToConditionExpression in scope any more - the only remaining
+      // ways to adapt a bare SchemaExpr receiver here (SchemaExprBoolBridge / schemaExprToDdbExpr,
+      // both reachable via DdbExpr's own implicit scope without an explicit import) resolve to
+      // DdbExpr, never to a bare, unconfigured ConditionExpression.
+      assertTrue(combined.isInstanceOf[DdbExpr[_, _]])
+      val ce       = interp(combined, cfg)
+      assertTrue(
+        attrPaths(ce).contains(List("customer_id")),
+        attrPaths(ce).contains(List("order_ref")),
+        attrPaths(ce).contains(List("status"))
+      )
+    },
+    test("import DdbExprApi._ alone: 3-term || chain no longer reaches ConditionExpression, honours config") {
+      import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
+      import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
+      import zio.dynamodb.blocks.ddbexpr.DdbExpr.{ DdbExprBoolSyntax, OpticDdbExprOps, OpticUpdateOps }
+      val cfg      = DynamoDBCodecDeriverConfig[Order]().withFieldNameMapper(NameMapper.SnakeCase)
+      val combined = Order.customerId === "c1" || Order.orderRef === "r1" || Order.status === Status.Shipped
+      assertTrue(combined.isInstanceOf[DdbExpr[_, _]])
+      val ce       = interp(combined, cfg)
+      assertTrue(
+        attrPaths(ce).contains(List("customer_id")),
+        attrPaths(ce).contains(List("order_ref")),
+        attrPaths(ce).contains(List("status"))
+      )
+    },
+    test("also importing SchemaExprBoolBridge: 3-term && chain stays DdbExpr and honours config") {
+      import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
+      import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
+      import zio.dynamodb.blocks.ddbexpr.DdbExpr.{
+        DdbExprBoolSyntax,
+        OpticDdbExprOps,
+        OpticUpdateOps,
+        SchemaExprBoolBridge
+      }
+      val cfg      = DynamoDBCodecDeriverConfig[Order]().withFieldNameMapper(NameMapper.SnakeCase)
+      val combined = Order.customerId === "c1" && Order.orderRef === "r1" && Order.status === Status.Shipped
+      // With SchemaExprBoolBridge also imported, the very first pairwise combination picks it
+      // (over ZB's own BooleanOps) - the result stays a properly-configured DdbExpr instead,
+      // equally safe, just a different node type.
+      assertTrue(combined.isInstanceOf[DdbExpr[_, _]])
+      val ce       = interp(combined, cfg)
+      assertTrue(
+        attrPaths(ce).contains(List("customer_id")),
+        attrPaths(ce).contains(List("order_ref")),
+        attrPaths(ce).contains(List("status"))
+      )
+    },
+    test("also importing SchemaExprBoolBridge: 3-term || chain stays DdbExpr and honours config") {
+      import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
+      import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
+      import zio.dynamodb.blocks.ddbexpr.DdbExpr.{
+        DdbExprBoolSyntax,
+        OpticDdbExprOps,
+        OpticUpdateOps,
+        SchemaExprBoolBridge
+      }
+      val cfg      = DynamoDBCodecDeriverConfig[Order]().withFieldNameMapper(NameMapper.SnakeCase)
+      val combined = Order.customerId === "c1" || Order.orderRef === "r1" || Order.status === Status.Shipped
+      assertTrue(combined.isInstanceOf[DdbExpr[_, _]])
+      val ce       = interp(combined, cfg)
+      assertTrue(
+        attrPaths(ce).contains(List("customer_id")),
+        attrPaths(ce).contains(List("order_ref")),
+        attrPaths(ce).contains(List("status"))
+      )
+    },
     test("default config: filtered field keeps its raw Scala name") {
       val cfg = DynamoDBCodecDeriverConfig[Order]()
       val ce  = interp(DdbExpr.Builtin(Order.customerId === "c1"), cfg)

--- a/schema-ddbexpr/src/test/scala/zio/dynamodb/DdbExprFilterConfigSpec.scala
+++ b/schema-ddbexpr/src/test/scala/zio/dynamodb/DdbExprFilterConfigSpec.scala
@@ -98,29 +98,21 @@ object DdbExprFilterConfigSpec extends ZIOSpecDefault {
     Order.schema.deriving(cfg.toDeriver).derive.recordFieldNameMap(scalaField)
 
   def spec = suite("DdbExprFilterConfigSpec")(
-    // Root cause of the `&&`/`||` config-loss bug that motivated this suite: `SchemaExpr` gets
-    // `&&`/`||` from ZB's own `SchemaExpr.BooleanOps` (native to SchemaExpr's companion,
-    // always in scope, no import needed) returning `SchemaExpr` again - safe, since the
-    // combined expression stays a `SchemaExpr` all the way to `.filter`/`.where`, which
-    // resolves it against the table's config. The bug was that `DdbExprApi._` used to
-    // ALSO put `schemaExprToConditionExpression` (a plain implicit *conversion*, not an
-    // extension method) into scope - competing to adapt the same `SchemaExpr` receiver, and
-    // winning when `DdbExpr.SchemaExprBoolBridge` wasn't separately imported, converting
-    // straight to a no-config `ConditionExpression` before `.filter` ever saw it. Fixed by
-    // moving that conversion (and its siblings) out of `DdbExprApiSyntax` into the
-    // separately-imported `LowLevelDdbExprSyntax` (`DdbExprLowLevel`) - so `DdbExprApi._` /
-    // `dsl._` alone can no longer reach that path at all, whether or not
-    // `SchemaExprBoolBridge` is also imported.
-    test("import DdbExprApi._ alone: 3-term && chain no longer reaches ConditionExpression, honours config") {
+    // `SchemaExpr` gets `&&` / `||` from zio-blocks' `SchemaExpr.BooleanOps` and stays a
+    // `SchemaExpr`; if `SchemaExprBoolBridge` is imported it is lifted to a `DdbExpr` instead.
+    // Either form carries the optic, so `.filter` / `.where` resolve the field names and
+    // literals against the table's config. These tests pin that a combined condition lands on
+    // one of those config-aware forms under both import shapes - never on a bare, already
+    // rendered `ConditionExpression`, which the builder would take verbatim.
+    test("import DdbExprApi._ alone: 3-term && chain resolves to a config-aware DdbExpr") {
       import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
       import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
       import zio.dynamodb.blocks.ddbexpr.DdbExpr.{ DdbExprBoolSyntax, OpticDdbExprOps, OpticUpdateOps }
       val cfg      = DynamoDBCodecDeriverConfig[Order]().withFieldNameMapper(NameMapper.SnakeCase)
       val combined = Order.customerId === "c1" && Order.orderRef === "r1" && Order.status === Status.Shipped
-      // No competing schemaExprToConditionExpression in scope any more - the only remaining
-      // ways to adapt a bare SchemaExpr receiver here (SchemaExprBoolBridge / schemaExprToDdbExpr,
-      // both reachable via DdbExpr's own implicit scope without an explicit import) resolve to
-      // DdbExpr, never to a bare, unconfigured ConditionExpression.
+      // With only DdbExprApi._ imported, the receiver is adapted via SchemaExprBoolBridge /
+      // schemaExprToDdbExpr - both reachable through DdbExpr's own implicit scope, no explicit
+      // import - so the chain is a DdbExpr carrying the optics, not a rendered ConditionExpression.
       assertTrue(combined.isInstanceOf[DdbExpr[_, _]])
       val ce       = interp(combined, cfg)
       assertTrue(
@@ -129,7 +121,7 @@ object DdbExprFilterConfigSpec extends ZIOSpecDefault {
         attrPaths(ce).contains(List("status"))
       )
     },
-    test("import DdbExprApi._ alone: 3-term || chain no longer reaches ConditionExpression, honours config") {
+    test("import DdbExprApi._ alone: 3-term || chain resolves to a config-aware DdbExpr") {
       import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
       import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
       import zio.dynamodb.blocks.ddbexpr.DdbExpr.{ DdbExprBoolSyntax, OpticDdbExprOps, OpticUpdateOps }
@@ -154,9 +146,8 @@ object DdbExprFilterConfigSpec extends ZIOSpecDefault {
       }
       val cfg      = DynamoDBCodecDeriverConfig[Order]().withFieldNameMapper(NameMapper.SnakeCase)
       val combined = Order.customerId === "c1" && Order.orderRef === "r1" && Order.status === Status.Shipped
-      // With SchemaExprBoolBridge also imported, the very first pairwise combination picks it
-      // (over ZB's own BooleanOps) - the result stays a properly-configured DdbExpr instead,
-      // equally safe, just a different node type.
+      // SchemaExprBoolBridge lifts the first pairwise combination to a DdbExpr; the whole
+      // chain is then a DdbExpr and `.filter` resolves it against the table config.
       assertTrue(combined.isInstanceOf[DdbExpr[_, _]])
       val ce       = interp(combined, cfg)
       assertTrue(

--- a/schema-ddbexpr/src/test/scala/zio/dynamodb/DdbExprFilterConfigSpec.scala
+++ b/schema-ddbexpr/src/test/scala/zio/dynamodb/DdbExprFilterConfigSpec.scala
@@ -98,22 +98,20 @@ object DdbExprFilterConfigSpec extends ZIOSpecDefault {
     Order.schema.deriving(cfg.toDeriver).derive.recordFieldNameMap(scalaField)
 
   def spec = suite("DdbExprFilterConfigSpec")(
-    // `SchemaExpr` gets `&&` / `||` from zio-blocks' `SchemaExpr.BooleanOps` and stays a
-    // `SchemaExpr`; if `SchemaExprBoolBridge` is imported it is lifted to a `DdbExpr` instead.
-    // Either form carries the optic, so `.filter` / `.where` resolve the field names and
-    // literals against the table's config. These tests pin that a combined condition lands on
-    // one of those config-aware forms under both import shapes - never on a bare, already
-    // rendered `ConditionExpression`, which the builder would take verbatim.
-    test("import DdbExprApi._ alone: 3-term && chain resolves to a config-aware DdbExpr") {
+    // A combined condition (`x === a && y === b && ...`) built from schema optics must reach
+    // `.filter` / `.where` as a `SchemaExpr` or a `DdbExpr` - either carries the optics, so
+    // field names and literals resolve against the table's config. It must NOT arrive as an
+    // already-rendered `ConditionExpression`, which `filter(ce: ...)` takes verbatim (config
+    // bypassed). `interp` below accepts only a `DdbExpr`, so a chain that resolved to
+    // `ConditionExpression` would not compile here; `attrPaths` then confirms the config
+    // actually threaded.
+    test("import DdbExprApi._ alone: 3-term && chain threads table config") {
       import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
       import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
       import zio.dynamodb.blocks.ddbexpr.DdbExpr.{ DdbExprBoolSyntax, OpticDdbExprOps, OpticUpdateOps }
       val cfg      = DynamoDBCodecDeriverConfig[Order]().withFieldNameMapper(NameMapper.SnakeCase)
       val combined = Order.customerId === "c1" && Order.orderRef === "r1" && Order.status === Status.Shipped
-      // With only DdbExprApi._ imported, the receiver is adapted via SchemaExprBoolBridge /
-      // schemaExprToDdbExpr - both reachable through DdbExpr's own implicit scope, no explicit
-      // import - so the chain is a DdbExpr carrying the optics, not a rendered ConditionExpression.
-      assertTrue(combined.isInstanceOf[DdbExpr[_, _]])
+      assertTrue(!combined.isInstanceOf[ConditionExpression[_]])
       val ce       = interp(combined, cfg)
       assertTrue(
         attrPaths(ce).contains(List("customer_id")),
@@ -121,13 +119,13 @@ object DdbExprFilterConfigSpec extends ZIOSpecDefault {
         attrPaths(ce).contains(List("status"))
       )
     },
-    test("import DdbExprApi._ alone: 3-term || chain resolves to a config-aware DdbExpr") {
+    test("import DdbExprApi._ alone: 3-term || chain threads table config") {
       import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
       import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
       import zio.dynamodb.blocks.ddbexpr.DdbExpr.{ DdbExprBoolSyntax, OpticDdbExprOps, OpticUpdateOps }
       val cfg      = DynamoDBCodecDeriverConfig[Order]().withFieldNameMapper(NameMapper.SnakeCase)
       val combined = Order.customerId === "c1" || Order.orderRef === "r1" || Order.status === Status.Shipped
-      assertTrue(combined.isInstanceOf[DdbExpr[_, _]])
+      assertTrue(!combined.isInstanceOf[ConditionExpression[_]])
       val ce       = interp(combined, cfg)
       assertTrue(
         attrPaths(ce).contains(List("customer_id")),
@@ -135,7 +133,7 @@ object DdbExprFilterConfigSpec extends ZIOSpecDefault {
         attrPaths(ce).contains(List("status"))
       )
     },
-    test("also importing SchemaExprBoolBridge: 3-term && chain stays DdbExpr and honours config") {
+    test("with SchemaExprBoolBridge imported: 3-term && chain threads table config") {
       import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
       import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
       import zio.dynamodb.blocks.ddbexpr.DdbExpr.{
@@ -146,9 +144,7 @@ object DdbExprFilterConfigSpec extends ZIOSpecDefault {
       }
       val cfg      = DynamoDBCodecDeriverConfig[Order]().withFieldNameMapper(NameMapper.SnakeCase)
       val combined = Order.customerId === "c1" && Order.orderRef === "r1" && Order.status === Status.Shipped
-      // SchemaExprBoolBridge lifts the first pairwise combination to a DdbExpr; the whole
-      // chain is then a DdbExpr and `.filter` resolves it against the table config.
-      assertTrue(combined.isInstanceOf[DdbExpr[_, _]])
+      assertTrue(!combined.isInstanceOf[ConditionExpression[_]])
       val ce       = interp(combined, cfg)
       assertTrue(
         attrPaths(ce).contains(List("customer_id")),
@@ -156,7 +152,7 @@ object DdbExprFilterConfigSpec extends ZIOSpecDefault {
         attrPaths(ce).contains(List("status"))
       )
     },
-    test("also importing SchemaExprBoolBridge: 3-term || chain stays DdbExpr and honours config") {
+    test("with SchemaExprBoolBridge imported: 3-term || chain threads table config") {
       import zio.dynamodb.blocks.ddbexpr.DdbExprApi._
       import zio.dynamodb.blocks.ddbexpr.DdbKeyExpr._
       import zio.dynamodb.blocks.ddbexpr.DdbExpr.{
@@ -167,7 +163,7 @@ object DdbExprFilterConfigSpec extends ZIOSpecDefault {
       }
       val cfg      = DynamoDBCodecDeriverConfig[Order]().withFieldNameMapper(NameMapper.SnakeCase)
       val combined = Order.customerId === "c1" || Order.orderRef === "r1" || Order.status === Status.Shipped
-      assertTrue(combined.isInstanceOf[DdbExpr[_, _]])
+      assertTrue(!combined.isInstanceOf[ConditionExpression[_]])
       val ce       = interp(combined, cfg)
       assertTrue(
         attrPaths(ce).contains(List("customer_id")),


### PR DESCRIPTION
x === a && y === b in a .filter/.where resolved to a bare ConditionExpression, so the Table's field-name mapper and literal encoding never applied — fixed by removing the low-level  SchemaExpr/DdbExpr → ConditionExpression implicit conversions (they were unused; the builders have real overloads).  