### PR TITLE
Clean up comments.

### DIFF
--- a/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/DdbExpr.scala
+++ b/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/DdbExpr.scala
@@ -126,9 +126,8 @@ trait DdbExprSyntax extends DerivedCodecSyntax {
 
   // Bridge: SchemaExpr → DdbExpr for !, &&, ||.
   // !SchemaExpr: SchemaExpr has no unary_! of its own, so this class provides it.
-  // &&/||: Since ZB v0.0.47+ removes &&/|| as direct methods on SchemaExpr (moving them
-  // to the BooleanOps companion implicit class), Scala 2 no longer suppresses this bridge
-  // for DdbExpr RHS. SchemaExpr && DdbExpr now resolves here instead of failing.
+  // &&/||: ZB v0.0.47+ moved &&/|| off SchemaExpr onto the BooleanOps companion implicit
+  // class, so under Scala 2, SchemaExpr && DdbExpr needs this explicit bridge to resolve.
   implicit class SchemaExprBoolBridge[S](val self: SchemaExpr[S, Boolean]) {
     def unary_! : DdbExpr[S, Boolean]                     = DdbExpr.Not(DdbExpr.Builtin(self))
     def &&(rhs: DdbExpr[S, Boolean]): DdbExpr[S, Boolean] = DdbExpr.And(DdbExpr.Builtin(self), rhs)

--- a/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/DerivedCodecSyntax.scala
+++ b/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/DerivedCodecSyntax.scala
@@ -21,10 +21,10 @@ import zio.blocks.schema.Schema
 import zio.dynamodb.blocks.DynamoDBCodecDeriverConfig
 import zio.dynamodb.blocks.schema.DynamoDBCodec
 
-// Shared by DdbExprSyntax and DdbKeyExprSyntax so both can resolve DynamoDBCodec[A]
-// implicitly without each declaring their own copy of derivedCodec. Trait linearization
-// dedupes a trait mixed in via multiple paths, so a facade extending both no longer hits
-// an ambiguous-implicit error the way importing DdbExpr._ and DdbKeyExpr._ together used to.
+// Shared by DdbExprSyntax and DdbKeyExprSyntax so both resolve DynamoDBCodec[A] implicitly
+// from the same derivedCodec rather than each declaring their own copy. Trait linearization
+// dedupes a trait mixed in via multiple paths, so a facade extending both resolves it without
+// an ambiguous-implicit error.
 trait DerivedCodecSyntax {
 
   // Memoises derived codecs by (Schema, config) identity so building an expression doesn't

--- a/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/dsl.scala
+++ b/schema-ddbexpr/src/main/scala/zio/dynamodb/blocks/ddbexpr/dsl.scala
@@ -35,8 +35,7 @@ package zio.dynamodb.blocks.ddbexpr
  *  `DdbExprSyntax` and `DdbKeyExprSyntax` each independently need a `DynamoDBCodec[A]` for any
  *  `A` with a `Schema[A]` in scope; both get it from the same inherited
  *  `DerivedCodecSyntax.derivedCodec` rather than each declaring their own copy, so mixing them
- *  together here doesn't hit the ambiguous-implicit error that importing `DdbExpr._` and
- *  `DdbKeyExpr._` together used to.
+ *  together here resolves without an ambiguous-implicit error.
  *
  *  This is purely a convenience for the common case — `DdbExprApi`, `DdbKeyExpr`, and
  *  `DdbExpr` remain independently importable exactly as before for callers who want only

--- a/schema-ddbexpr/src/test/scala/zio/dynamodb/DdbExprUpdateConfigSpec.scala
+++ b/schema-ddbexpr/src/test/scala/zio/dynamodb/DdbExprUpdateConfigSpec.scala
@@ -29,10 +29,10 @@ import zio.test.Assertion._
  * `DynamoDBCodecDeriverConfig`, so a `set` / `add` / … writes the same attribute name and
  * the same operand encoding as the item body a `put` writes.
  *
- * The `Variant` (sealed-trait) operand cases are the point: before this, `Task.score.set(x)`
- * encoded eagerly via an ambient `implicit DynamoDBCodec[A]` (default config if no `given`
- * was in scope), so a sealed-trait operand under a non-default `enumValuesAsStrings` /
- * `caseNameMapper` silently disagreed with the body.
+ * The `Variant` (sealed-trait) operand cases are the point: a sealed-trait operand in
+ * `Task.score.set(x)` must encode consistently with the body under a non-default
+ * `enumValuesAsStrings` / `caseNameMapper`, not via an ambient, possibly differently
+ * configured `implicit DynamoDBCodec[A]`.
  */
 object DdbExprUpdateConfigSpec extends ZIOSpecDefault {
 

--- a/schema-ddbexpr/src/test/scala/zio/dynamodb/DslSpec.scala
+++ b/schema-ddbexpr/src/test/scala/zio/dynamodb/DslSpec.scala
@@ -27,16 +27,14 @@ import zio.test._
 import zio.test.Assertion._
 
 /**
- * Every other spec in this module imports `DdbExprApi._`, `DdbKeyExpr._`, and a selective
- *  subset of `DdbExpr` members separately, with a comment explaining why: `DdbExpr` and
- *  `DdbKeyExpr` each used to declare their own `derivedCodec`, so a plain `DdbExpr._` wildcard
- *  alongside `DdbKeyExpr._` was an ambiguous-implicit error. This spec exercises the single
- *  `import zio.dynamodb.blocks.ddbexpr.dsl._` facade across CRUD, key expressions, condition
- *  combinators (`&&`), and update syntax in one file — the exact combination that used to
- *  require three-to-four import lines and the workaround comment — to prove the facade
- *  actually replaces all of it, not just the trivial single-predicate case. Note `put`/`get`/
- *  `scan` etc. are callable unqualified (no `DdbExprApi.` prefix needed) since `dsl` mixes
- *  their defining trait in directly.
+ * Exercises the single `import zio.dynamodb.blocks.ddbexpr.dsl._` facade across CRUD, key
+ *  expressions, condition combinators (`&&`), and update syntax in one file, proving it covers
+ *  every piece a real call site needs — not just the trivial single-predicate case. Other specs
+ *  in this module import `DdbExprApi._`, `DdbKeyExpr._`, and a selective subset of `DdbExpr`
+ *  members separately (see [[DerivedCodecSyntax]] for why a plain `DdbExpr._` wildcard needs
+ *  care alongside `DdbKeyExpr._`); `dsl._` avoids that entirely. Note `put`/`get`/`scan` etc.
+ *  are callable unqualified (no `DdbExprApi.` prefix needed) since `dsl` mixes their defining
+ *  trait in directly.
  */
 object DslSpec extends ZIOSpecDefault {
 

--- a/schema-dynamodb/src/test/scala/zio/dynamodb/blocks/schema/DynamoDBCodecDeriverSpec.scala
+++ b/schema-dynamodb/src/test/scala/zio/dynamodb/blocks/schema/DynamoDBCodecDeriverSpec.scala
@@ -648,10 +648,10 @@ object DynamoDBCodecDeriverSpec extends ZIOSpecDefault {
       )
     },
     test("decoder is safe to reuse across multiple decode calls") {
-      // Regression: idx/regs/error used to be allocated outside the returned decoder
-      // function, so a decoder captured once and invoked repeatedly (a natural thing to
-      // do to avoid re-fetching `codec.decoder` per call) silently returned the first
-      // call's result on every subsequent call.
+      // Decoder-local state (idx/regs/error) must live inside the returned decoder function,
+      // not be shared across calls — a decoder captured once and invoked repeatedly (a natural
+      // thing to do, to avoid re-fetching `codec.decoder` per call) must not leak state
+      // between calls.
       val codec  = codecFor[Person]
       val decode = codec.decoder
       val r1     = decode(codec.encoder(Person("Alice", 30)))


### PR DESCRIPTION
Comments should not refer to previous code state.